### PR TITLE
Fix PermissionError does not exist on Py2

### DIFF
--- a/dist.py
+++ b/dist.py
@@ -418,11 +418,13 @@ class Controller(object):
             log('Removing working directory: {}'.format(workdir))
             try:
                 shutil.rmtree(workdir)
-            except PermissionError:
+            except OSError as e:
                 # On Windows, removal of `.git` directory may fail.
-                log('Failed to clean-up working directory.'
-                    'Please remove the working directory manually: {}'.format(
-                        workdir))
+                log('''\
+Failed to clean-up working directory: {}
+
+Please remove the working directory manually: {}
+'''.format(e, workdir))
 
     def verify_linux(
             self, target, nccl_assets, cuda_version, python_version,

--- a/dist.py
+++ b/dist.py
@@ -421,7 +421,7 @@ class Controller(object):
             except OSError as e:
                 # TODO(kmaehashi): On Windows, removal of `.git` directory may
                 # fail with PermissionError (on Python 3) or OSError (on
-                # Python 2).
+                # Python 2). Note that PermissionError inherits OSError.
                 log('Failed to clean-up working directory: {}\n\n'
                     'Please remove the working directory manually: {}'.format(
                         e, workdir))

--- a/dist.py
+++ b/dist.py
@@ -419,12 +419,12 @@ class Controller(object):
             try:
                 shutil.rmtree(workdir)
             except OSError as e:
-                # On Windows, removal of `.git` directory may fail.
-                log('''\
-Failed to clean-up working directory: {}
-
-Please remove the working directory manually: {}
-'''.format(e, workdir))
+                # TODO(kmaehashi): On Windows, removal of `.git` directory may
+                # fail with PermissionError (on Python 3) or OSError (on
+                # Python 2).
+                log('Failed to clean-up working directory: {}\n\n'
+                    'Please remove the working directory manually: {}'.format(
+                        e, workdir))
 
     def verify_linux(
             self, target, nccl_assets, cuda_version, python_version,


### PR DESCRIPTION
This is mainly intended to avoid `F821 undefined name 'PermissionError'` with flake8.
(we do not ship wheels for Windows + Py2)