### PR TITLE
Delay docker image build to fail fast

### DIFF
--- a/dist.py
+++ b/dist.py
@@ -227,9 +227,6 @@ class Controller(object):
         else:
             raise RuntimeError('unknown target')
 
-        # Creates a Docker image to build distribution.
-        self._create_builder_linux(image_tag, base_image)
-
         # Arguments for the agent.
         agent_args = [
             '--action', action,
@@ -277,6 +274,9 @@ class Controller(object):
                 with open('{}/description.rst'.format(workdir), 'w') as f:
                     f.write(long_description)
 
+            # Creates a Docker image to build distribution.
+            self._create_builder_linux(image_tag, base_image)
+
             # Build.
             log('Starting build')
             self._run_container(image_tag, workdir, agent_args)
@@ -297,7 +297,6 @@ class Controller(object):
             dist, tests):
         """Verify a single distribution for Linux."""
 
-        # Creates a Docker image to verify specified distribution.
         if target == 'sdist':
             image_tag = 'cupy-verifier-sdist'
             base_image = SDIST_CONFIG['verify_image']
@@ -325,8 +324,6 @@ class Controller(object):
             self, image_tag, base_image, dist, tests, python_version,
             nccl_assets, nccl_config):
         dist_basename = os.path.basename(dist)
-
-        self._create_verifier_linux(image_tag, base_image)
 
         # Arguments for the agent.
         agent_args = [
@@ -364,6 +361,9 @@ class Controller(object):
                 extract_nccl_archive(nccl_config, nccl_assets, nccl_workdir)
             else:
                 log('NCCL is not installed for verification')
+
+            # Creates a Docker image to verify specified distribution.
+            self._create_verifier_linux(image_tag, base_image)
 
             # Verify.
             log('Starting verification')


### PR DESCRIPTION
This is to fail fast (detect error like specifying invalid path to NCCL assets, as fast as possible, before doing docker image build).