### PR TITLE
Support build on non-root environment

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -50,5 +50,11 @@ RUN for VERSION in ${python_versions}; do \
 RUN yum -y install python-setuptools && yum clean all
 RUN easy_install argparse
 
+# Install NCCL
+COPY nccl /nccl
+RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
+    ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
+    ldconfig
+
 COPY agent.py /
 ENTRYPOINT ["/agent.py"]

--- a/builder/agent.py
+++ b/builder/agent.py
@@ -35,9 +35,6 @@ class BuilderAgent(object):
             '--source', type=str, required=True,
             help='Path to the CuPy source directory')
         parser.add_argument(
-            '--nccl', type=str,
-            help='Path to the extracted NCCL binary distribution directory')
-        parser.add_argument(
             '--python', type=str,
             help='Python version to use for setup')
         parser.add_argument(
@@ -51,15 +48,6 @@ class BuilderAgent(object):
 
     def main(self):
         args, setup_args = self.parse_args()
-
-        if args.nccl:
-            self._log('Installing NCCL...')
-            for f in glob.glob('{0}/lib/lib*'.format(args.nccl)):
-                shutil.copy(f, '/usr/local/cuda/lib64')
-            for f in glob.glob('{0}/include/*.h'.format(args.nccl)):
-                shutil.copy(f, '/usr/local/cuda/include')
-        else:
-            self._log('Skip NCCL installation')
 
         pycommand = [sys.executable]
         if args.python:

--- a/builder/agent.py
+++ b/builder/agent.py
@@ -7,9 +7,7 @@ Additional dependency can be specified in Dockerfile.
 """
 
 import argparse
-import glob
 import os
-import shutil
 import subprocess
 import sys
 import time

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -37,5 +37,14 @@ RUN for VERSION in ${python_versions}; do \
     done && \
     pyenv global system
 
+# Install NCCL
+COPY nccl /nccl
+RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
+    ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
+    ldconfig
+
+# Use /tmp as a temporary home to install package.
+ENV HOME /tmp
+
 COPY agent.py /
 ENTRYPOINT ["/agent.py"]

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -32,5 +32,14 @@ RUN for VERSION in ${python_versions}; do \
 RUN yum -y install python-setuptools && yum clean all
 RUN easy_install argparse
 
+# Install NCCL
+COPY nccl /nccl
+RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
+    ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
+    ldconfig
+
+# Use /tmp as a temporary home to install package.
+ENV HOME /tmp
+
 COPY agent.py /
 ENTRYPOINT ["/agent.py"]

--- a/verifier/agent.py
+++ b/verifier/agent.py
@@ -7,9 +7,7 @@ Additional dependency can be specified in Dockerfile.
 """
 
 import argparse
-import glob
 import os
-import shutil
 import subprocess
 import sys
 import time

--- a/verifier/agent.py
+++ b/verifier/agent.py
@@ -32,9 +32,6 @@ class VerifierAgent(object):
             '--dist', type=str,
             help='Path to the distribution (sdist or wheel)')
         parser.add_argument(
-            '--nccl', type=str,
-            help='Path to the extracted NCCL binary distribution directory')
-        parser.add_argument(
             '--python', type=str,
             help='Python version to use for setup')
         parser.add_argument(
@@ -46,15 +43,6 @@ class VerifierAgent(object):
     def main(self):
         args, pytest_args = self.parse_args()
 
-        if args.nccl:
-            self._log('Installing NCCL...')
-            for f in glob.glob('{0}/lib/lib*'.format(args.nccl)):
-                shutil.copy(f, '/usr/local/cuda/lib64')
-            for f in glob.glob('{0}/include/*.h'.format(args.nccl)):
-                shutil.copy(f, '/usr/local/cuda/include')
-        else:
-            self._log('Skip NCCL installation')
-
         pycommand = [sys.executable]
         if args.python:
             os.environ['PYENV_VERSION'] = args.python
@@ -64,7 +52,9 @@ class VerifierAgent(object):
             self._log('Using Python from system')
 
         self._log('Installing distribution...')
-        cmdline = pycommand + ['-m', 'pip', 'install', '-vvv', args.dist]
+        cmdline = pycommand + [
+            '-m', 'pip', 'install', '-vvv', '--user', args.dist,
+        ]
         self._run(*cmdline)
 
         try:


### PR DESCRIPTION
This is required to build on new Jenkins environment.

* build/verify phase: install NCCL during `docker build` instead of `docker run`.
* verify phase: test using `HOME=/tmp` and `pip install --local`