### PR TITLE
Fixes for v8.0.0b5+ build

### DIFF
--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -1,11 +1,14 @@
 #!/bin/bash -uex
 
+CUDA="9.2"
+PYTHON="3.8.0"
+
 # Download NCCL
-gsutil -m cp -r gs://chainer-artifacts-pfn-public-ci/cupy-release-tools/nccl .
+./download_nccl.sh "${CUDA}"
 ls -al nccl
 
 # Clone CuPy
 git clone --recursive https://github.com/cupy/cupy.git cupy
 
 # Build and Verify
-./build.sh 9.2 3.8.0
+./build.sh "${CUDA}" "${PYTHON}"

--- a/.pfnci/test.sh
+++ b/.pfnci/test.sh
@@ -5,7 +5,7 @@ gsutil -m cp -r gs://chainer-artifacts-pfn-public-ci/cupy-release-tools/nccl .
 ls -al nccl
 
 # Clone CuPy
-git clone https://github.com/cupy/cupy.git cupy
+git clone --recursive https://github.com/cupy/cupy.git cupy
 
 # Build and Verify
 ./build.sh 9.2 3.8.0

--- a/.pfnci/wheel-windows/main.bat
+++ b/.pfnci/wheel-windows/main.bat
@@ -8,7 +8,7 @@ set BRANCH=%3
 PowerShell .pfnci\wheel-windows\install_cudnn.ps1 -cuda %CUDA%
 
 :: Clone CuPy
-git clone https://github.com/cupy/cupy.git cupy
+git clone --recursive https://github.com/cupy/cupy.git cupy
 git -C cupy checkout %BRANCH%
 
 :: Build

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -56,9 +56,12 @@ RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
     ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
     ldconfig
 
-# Install g++-7 for CuPy v8 build
+# Install g++-6 for CuPy v8 build
 RUN yum install -y centos-release-scl && \
-    yum install -y devtoolset-7-gcc-c++ && \
+    yum clean all
+RUN perl -pi -e 's|^#baseurl=http://mirror.centos.org/centos/6/sclo/\$basearch/rh/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/6.8/sclo/\$basearch/rh/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
+    perl -pi -e 's|^mirrorlist=|#mirrorlist=|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
+    yum install -y devtoolset-6-gcc-c++ && \
     yum clean all
 
 COPY build-wrapper /

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -56,5 +56,12 @@ RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
     ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
     ldconfig
 
+# Install g++-7 for CuPy v8 build
+RUN yum install -y centos-release-scl && \
+    yum install -y devtoolset-7-gcc-c++ && \
+    yum clean all
+
+COPY build-wrapper /
 COPY agent.py /
+
 ENTRYPOINT ["/agent.py"]

--- a/builder/agent.py
+++ b/builder/agent.py
@@ -64,9 +64,9 @@ class BuilderAgent(object):
         os.chdir(args.source)
         try:
             self._log('Running CuPy setup...')
-            cmdline = (
-                ['/build-wrapper'] + pycommand +
-                ['setup.py', args.action] + setup_args)
+            cmdline = pycommand + ['setup.py', args.action] + setup_args
+            if sys.platform.startswith('linux'):
+                cmdline = ['/build-wrapper'] + cmdline
             self._run(*cmdline)
         finally:
             if args.chown:

--- a/builder/agent.py
+++ b/builder/agent.py
@@ -64,7 +64,9 @@ class BuilderAgent(object):
         os.chdir(args.source)
         try:
             self._log('Running CuPy setup...')
-            cmdline = pycommand + ['setup.py', args.action] + setup_args
+            cmdline = (
+                ['/build-wrapper'] + pycommand +
+                ['setup.py', args.action] + setup_args)
             self._run(*cmdline)
         finally:
             if args.chown:

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /opt/rh/devtoolset-7/enable
+source /opt/rh/devtoolset-6/enable
 "$@"

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+source /opt/rh/devtoolset-7/enable
+"$@"

--- a/dist_config.py
+++ b/dist_config.py
@@ -11,7 +11,7 @@ SDIST_CONFIG = {
     'nccl': {
         'type': 'v2-tar',
         'files': [
-            'nccl_2.5.6-1+cuda9.0_x86_64.txz',
+            'nccl_2.4.8-1+cuda9.2_x86_64.txz',
         ],
     },
     'verify_image': 'nvidia/cuda:9.2-cudnn7-devel-{system}',
@@ -162,7 +162,7 @@ WHEEL_LINUX_CONFIGS = {
         'nccl': {
             'type': 'v2-tar',
             'files': [
-                'nccl_2.5.6-1+cuda10.0_x86_64.txz',
+                'nccl_2.6.4-1+cuda10.0_x86_64.txz',
             ],
         },
         'verify_image': 'nvidia/cuda:10.0-devel-{system}',
@@ -181,7 +181,7 @@ WHEEL_LINUX_CONFIGS = {
         'nccl': {
             'type': 'v2-tar',
             'files': [
-                'nccl_2.5.6-1+cuda10.1_x86_64.txz',
+                'nccl_2.7.8-1+cuda10.1_x86_64.txz',
             ],
         },
         'verify_image': 'nvidia/cuda:10.1-devel-{system}',
@@ -200,7 +200,7 @@ WHEEL_LINUX_CONFIGS = {
         'nccl': {
             'type': 'v2-tar',
             'files': [
-                'nccl_2.5.6-2+cuda10.2_x86_64.txz',
+                'nccl_2.7.8-2+cuda10.2_x86_64.txz',
             ],
         },
         'verify_image': 'nvidia/cuda:10.2-devel-{system}',

--- a/dist_config.py
+++ b/dist_config.py
@@ -7,7 +7,7 @@ CYTHON_VERSION = '0.29.21'
 # See descriptions of WHEEL_LINUX_CONFIGS for details.
 # Note that cuDNN and NCCL must be available for sdist.
 SDIST_CONFIG = {
-    'image': 'nvidia/cuda:9.0-cudnn7-devel-centos7',
+    'image': 'nvidia/cuda:9.0-cudnn7-devel-centos6',
     'nccl': {
         'type': 'v2-tar',
         'files': [

--- a/dist_config.py
+++ b/dist_config.py
@@ -7,14 +7,14 @@ CYTHON_VERSION = '0.29.21'
 # See descriptions of WHEEL_LINUX_CONFIGS for details.
 # Note that cuDNN and NCCL must be available for sdist.
 SDIST_CONFIG = {
-    'image': 'nvidia/cuda:9.0-cudnn7-devel-centos6',
+    'image': 'nvidia/cuda:9.2-cudnn7-devel-centos6',
     'nccl': {
         'type': 'v2-tar',
         'files': [
             'nccl_2.5.6-1+cuda9.0_x86_64.txz',
         ],
     },
-    'verify_image': 'nvidia/cuda:9.0-cudnn7-devel-{system}',
+    'verify_image': 'nvidia/cuda:9.2-cudnn7-devel-{system}',
     'verify_systems': ['ubuntu18.04'],
 }
 

--- a/dist_config.py
+++ b/dist_config.py
@@ -15,7 +15,7 @@ SDIST_CONFIG = {
         ],
     },
     'verify_image': 'nvidia/cuda:9.0-cudnn7-devel-{system}',
-    'verify_systems': ['ubuntu16.04'],
+    'verify_systems': ['ubuntu18.04'],
 }
 
 

--- a/dist_config.py
+++ b/dist_config.py
@@ -323,16 +323,6 @@ If you want to build CuPy from `source distribution <https://pypi.python.org/pyp
 # - `requires`: a list of required packages; this is needed as some older
 #               NumPy does not support newer Python.
 WHEEL_PYTHON_VERSIONS = {
-    '2.7.6': {
-        'python_tag': 'cp27',
-        'abi_tag': 'cp27mu',
-        'requires': [],
-    },
-    '3.4.7': {
-        'python_tag': 'cp34',
-        'abi_tag': 'cp34m',
-        'requires': [],
-    },
     '3.5.1': {
         'python_tag': 'cp35',
         'abi_tag': 'cp35m',

--- a/dist_config.py
+++ b/dist_config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Cython version to cythonize the code.
-CYTHON_VERSION = '0.28.3'
+CYTHON_VERSION = '0.29.21'
 
 # Key-value of sdist build settings.
 # See descriptions of WHEEL_LINUX_CONFIGS for details.

--- a/download_nccl.sh
+++ b/download_nccl.sh
@@ -5,7 +5,7 @@ CUDA="${1}"
 mkdir -p nccl/
 case ${CUDA} in
   sdist )
-    wget -O "nccl/nccl_2.1.4-1+cuda9.0_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.1.4-1%2Bcuda9.0_x86_64.txz"
+    wget -O "nccl/nccl_2.5.6-1+cuda9.0_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.5.6-1%2Bcuda9.0_x86_64.txz"
     ;;
   7.0 )
     echo "NCCL is not supported in CUDA 7.0"

--- a/download_nccl.sh
+++ b/download_nccl.sh
@@ -3,38 +3,35 @@
 CUDA="${1}"
 
 mkdir -p nccl/
+cd nccl
+
 case ${CUDA} in
   sdist )
-    wget -O "nccl/nccl_2.5.6-1+cuda9.0_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.5.6-1%2Bcuda9.0_x86_64.txz"
-    ;;
-  7.0 )
-    echo "NCCL is not supported in CUDA 7.0"
-    exit 1
-    ;;
-  7.5 )
-    wget -O "nccl/libnccl1_1.2.3-1.cuda7.5_amd64.deb" "https://github.com/NVIDIA/nccl/releases/download/v1.2.3-1%2Bcuda7.5/libnccl1_1.2.3-1.cuda7.5_amd64.deb"
-    wget -O "nccl/libnccl-dev_1.2.3-1.cuda7.5_amd64.deb" "https://github.com/NVIDIA/nccl/releases/download/v1.2.3-1%2Bcuda7.5/libnccl-dev_1.2.3-1.cuda7.5_amd64.deb"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.4/nccl_2.4.8-1+cuda9.2_x86_64.txz"
     ;;
   8.0 )
-    wget -O "nccl/nccl_2.2.13-1+cuda8.0_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.2.13-1%2Bcuda8.0_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.2/nccl_2.2.13-1+cuda8.0_x86_64.txz"
     ;;
   9.0 )
-    wget -O "nccl/nccl_2.5.6-1+cuda9.0_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.5.6-1%2Bcuda9.0_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.5/nccl_2.5.6-1+cuda9.0_x86_64.txz"
     ;;
   9.1 )
-    wget -O "nccl/nccl_2.1.15-1+cuda9.1_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.1.15-1%2Bcuda9.1_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.1/nccl_2.1.15-1+cuda9.1_x86_64.txz"
     ;;
   9.2 )
-    wget -O "nccl/nccl_2.4.8-1+cuda9.2_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.4.8-1%2Bcuda9.2_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.4/nccl_2.4.8-1+cuda9.2_x86_64.txz"
     ;;
   10.0 )
-    wget -O "nccl/nccl_2.5.6-1+cuda10.0_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.5.6-1%2Bcuda10.0_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.6/nccl_2.6.4-1+cuda10.0_x86_64.txz"
     ;;
   10.1 )
-    wget -O "nccl/nccl_2.5.6-1+cuda10.1_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.5.6-1%2Bcuda10.1_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.7/nccl_2.7.8-1+cuda10.1_x86_64.txz"
     ;;
   10.2 )
-    wget -O "nccl/nccl_2.5.6-2+cuda10.2_x86_64.txz" "https://s3-ap-northeast-1.amazonaws.com/pfn-internal-public/cupy/nccl_2.5.6-2%2Bcuda10.2_x86_64.txz"
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.7/nccl_2.7.8-1+cuda10.2_x86_64.txz"
+    ;;
+  11.0 )
+    curl -LO "http://developer.download.nvidia.com/compute/redist/nccl/v2.7/nccl_2.7.8-1+cuda11.0_x86_64.txz"
     ;;
   * )
     echo "Unsupported CUDA version: ${1}"

--- a/release-tests/common/test_cusolver.py
+++ b/release-tests/common/test_cusolver.py
@@ -1,9 +1,11 @@
 import unittest
 
-import cupy
-import cupy.cuda.cusolver as libcusolver  # NOQA
+import cupy.cuda
 
 
 class TestCusolver(unittest.TestCase):
     def test_enabled(self):
         assert cupy.cuda.cusolver_enabled
+
+    def test_available(self):
+        assert cupy.cuda.cusolver is not None

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -10,7 +10,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # Install pyenv requirements.
 # https://github.com/pyenv/pyenv/wiki/Common-build-problems#requirements
-RUN apt-get -y update && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
     apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev \
     libncursesw5-dev xz-utils tk-dev && \

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -1,7 +1,8 @@
 ARG base_image
 FROM ${base_image}
 
-RUN apt-get -y update && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
     apt-get -y install gcc g++ make patch git && \
     apt-get -y install libbz2-dev libssl-dev libreadline-dev libffi-dev && \
     apt-get -y install python && \


### PR DESCRIPTION
* Support submodule (CUB)
* Use gcc-6 from devtoolset-6
    * Using devtoolset-6 from CentOS 6.8 vault (legacy software archive), because devtoolset-6 is no longer available in the latest CentOS SCL. gcc-7 is available in the latest SCL, but it does not work with CUDA 9.0.
* Use CentOS 6 for sdist (to use devtoolset-6)
* Fix smoke test code for `cuda_backends` refactoring (note that the test code must work with v7 and v8)

The followings are not directly related to v8b5 (maybe I can separate a PR):
* Bump Cython version
* Remove Python 2.7 and 3.4
* Use latest NCCL for sdist
