### PR TITLE
Support CUDA 11.0

### DIFF
--- a/.pfnci/wheel-windows/build.ps1
+++ b/.pfnci/wheel-windows/build.ps1
@@ -45,6 +45,9 @@ switch ($cuda) {
     "10.2" {
         $cuda_path = $Env:CUDA_PATH_V10_2
     }
+    "11.0" {
+        $cuda_path = $Env:CUDA_PATH_V11_0
+    }
     default {
          throw "Unsupported CUDA version: $cuda"
     }

--- a/.pfnci/wheel-windows/install_cudnn.ps1
+++ b/.pfnci/wheel-windows/install_cudnn.ps1
@@ -19,39 +19,49 @@ function install_cudnn([String]$cudnn_zip, [String]$cuda_root) {
 switch ($cuda) {
     "8.0" {
         $cuda_path = $Env:CUDA_PATH_V8_0
+        $cudnn_version = "7.1.3"
         $cudnn_archive = "cudnn-8.0-windows10-x64-v7.1-ga.zip"
     }
     "9.0" {
         $cuda_path = $Env:CUDA_PATH_V9_0
+        $cudnn_version = "7.6.5"
         $cudnn_archive = "cudnn-9.0-windows10-x64-v7.6.5.32.zip"
     }
     "9.1" {
         $cuda_path = $Env:CUDA_PATH_V9_1
+        $cudnn_version = "7.1.3"
         $cudnn_archive = "cudnn-9.1-windows10-x64-v7.1.zip"
     }
     "9.2" {
         $cuda_path = $Env:CUDA_PATH_V9_2
+        $cudnn_version = "7.6.5"
         $cudnn_archive = "cudnn-9.2-windows10-x64-v7.6.5.32.zip"
     }
     "10.0" {
         $cuda_path = $Env:CUDA_PATH_V10_0
+        $cudnn_version = "7.6.5"
         $cudnn_archive = "cudnn-10.0-windows10-x64-v7.6.5.32.zip"
     }
     "10.1" {
         $cuda_path = $Env:CUDA_PATH_V10_1
+        $cudnn_version = "7.6.5"
         $cudnn_archive = "cudnn-10.1-windows10-x64-v7.6.5.32.zip"
     }
     "10.2" {
         $cuda_path = $Env:CUDA_PATH_V10_2
+        $cudnn_version = "7.6.5"
         $cudnn_archive = "cudnn-10.2-windows10-x64-v7.6.5.32.zip"
+    }
+    "11.0" {
+        $cuda_path = $Env:CUDA_PATH_V11_0
+        $cudnn_version = "8.0.2"
+        $cudnn_archive = "cudnn-11.0-windows-x64-v8.0.2.39.zip"
     }
     default {
          throw "Unsupported CUDA version: $cuda"
     }
 }
 
-
-# https://console.cloud.google.com/storage/browser/tmp-asia-pfn-public-ci/cupy-release-tools/cudnn/
-gsutil -q -m cp -r gs://tmp-asia-pfn-public-ci/cupy-release-tools/cudnn/$cudnn_archive .
+curl -LO "https://developer.download.nvidia.com/compute/redist/cudnn/v${cudnn_version}/${cudnn_archive}"
 
 install_cudnn $cudnn_archive $cuda_path

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -6,23 +6,6 @@ RUN yum -y update && \
     yum -y install bzip2-devel openssl-devel readline-devel libffi-devel && \
     yum clean all
 
-# Install OpenSSL; Python 3.7 requires OpenSSL 1.0.2 or 1.1 compatible libssl
-# with X509_VERIFY_PARAM_set1_host, whereas CentOS 6 provides 0.9.8 and 1.0.1.
-ENV OPENSSL_ROOT=openssl-1.0.2o
-ENV OPENSSL_FILE=${OPENSSL_ROOT}.tar.gz
-ENV OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
-RUN curl -s -q -o "${OPENSSL_FILE}" "https://www.openssl.org/source/${OPENSSL_FILE}" && \
-    echo "${OPENSSL_HASH}  ${OPENSSL_FILE}" | sha256sum -cw --quiet - && \
-    tar xf "${OPENSSL_FILE}" && \
-    cd "${OPENSSL_ROOT}" && \
-    ./config no-ssl2 no-shared -fPIC --prefix=/usr/local/ssl &> /tmp/openssl-config.log && \
-    make &> /tmp/openssl-make.log && \
-    make install_sw &> /tmp/openssl-make-install_sw.log && \
-    cd .. && \
-    rm -rf "${OPENSSL_ROOT}" "${OPENSSL_ROOT}.tar.gz"
-ENV CFLAGS=-I/usr/local/ssl/include
-ENV LDFLAGS=-L/usr/local/ssl/lib
-
 # Install pyenv.
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
@@ -30,40 +13,26 @@ ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 
 # Install Python.
 ARG python_versions
-RUN for VERSION in ${python_versions}; do \
-      echo "Installing Python ${VERSION}..." && \
-      pyenv install ${VERSION}; \
-    done;
-
-# Install Python libraries.
 ARG cython_version
-RUN for VERSION in ${python_versions}; do \
-      echo "Installing libraries on Python ${VERSION}..." && \
-      pyenv global ${VERSION} && \
-      pip install -U pip setuptools && \
-      pip install argparse && \
-      pip install Cython==${cython_version} wheel auditwheel; \
-    done && \
-    pyenv global system
+COPY setup_python.sh /
+RUN /setup_python.sh "${python_versions}" "${cython_version}"
 
-# Install requirements for agents.
-RUN yum -y install python-setuptools && yum clean all
-RUN easy_install argparse
+# Install devtoolset (g++) for CuPy v8 build.
+COPY setup_devtoolset.sh /
+RUN /setup_devtoolset.sh
 
-# Install NCCL
+# Install NCCL.
 COPY nccl /nccl
 RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
     ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
     ldconfig
 
-# Install g++-6 for CuPy v8 build
-RUN yum install -y centos-release-scl && \
+# Install requirements for agents.
+RUN yum -y install python-setuptools && \
     yum clean all
-RUN perl -pi -e 's|^#baseurl=http://mirror.centos.org/centos/6/sclo/\$basearch/rh/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/6.8/sclo/\$basearch/rh/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
-    perl -pi -e 's|^mirrorlist=|#mirrorlist=|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo && \
-    yum install -y devtoolset-6-gcc-c++ && \
-    yum clean all
+RUN easy_install argparse
 
+# Add build agent.
 COPY build-wrapper /
 COPY agent.py /
 

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -1,4 +1,11 @@
 #!/bin/bash
 
-source /opt/rh/devtoolset-6/enable
+if [ -f /opt/rh/devtoolset-6/enable ]; then
+    # CentOS 6
+    source /opt/rh/devtoolset-6/enable
+else
+    # CentOS 7 (CUDA 11.0+)
+    source /opt/rh/devtoolset-7/enable
+fi
+
 "$@"

--- a/builder/setup_devtoolset.sh
+++ b/builder/setup_devtoolset.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -uex
+
+yum install -y centos-release-scl
+
+if [ $(rpm --eval '%{rhel}') == 6 ]; then
+    # CentOS 6
+    perl -pi -e 's|^#baseurl=http://mirror.centos.org/centos/6/sclo/\$basearch/rh/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/6.8/sclo/\$basearch/rh/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+    perl -pi -e 's|^mirrorlist=|#mirrorlist=|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+    yum install -y devtoolset-6-gcc-c++
+else
+    # CentOS 7
+    yum install -y devtoolset-7-gcc-c++
+fi
+
+yum clean all

--- a/builder/setup_python.sh
+++ b/builder/setup_python.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -uex
+
+PYTHON_VERSIONS=$1
+CYTHON_VERSION=$2
+
+# Install OpenSSL for CentOS 6; Python 3.7 requires OpenSSL 1.0.2 or 1.1
+# compatible libssl with X509_VERIFY_PARAM_set1_host, whereas CentOS 6 provides
+# 0.9.8 and 1.0.1.
+if [ $(rpm --eval '%{rhel}') == 6 ]; then
+    OPENSSL_ROOT=openssl-1.0.2o
+    OPENSSL_FILE=${OPENSSL_ROOT}.tar.gz
+    OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
+    curl -s -q -o "${OPENSSL_FILE}" "https://www.openssl.org/source/${OPENSSL_FILE}"
+    echo "${OPENSSL_HASH}  ${OPENSSL_FILE}" | sha256sum -cw --quiet -
+    tar xf "${OPENSSL_FILE}"
+    pushd "${OPENSSL_ROOT}"
+    ./config no-ssl2 no-shared -fPIC --prefix=/usr/local/ssl &> /tmp/openssl-config.log
+    make &> /tmp/openssl-make.log
+    make install_sw &> /tmp/openssl-make-install_sw.log
+    popd
+    rm -rf "${OPENSSL_ROOT}" "${OPENSSL_ROOT}.tar.gz"
+
+    export CFLAGS=-I/usr/local/ssl/include
+    export LDFLAGS=-L/usr/local/ssl/lib
+fi
+
+# Install Python
+for VERSION in ${PYTHON_VERSIONS}; do
+    pyenv install ${VERSION} &
+done
+wait
+
+# Install Python libraries.
+for VERSION in ${PYTHON_VERSIONS}; do \
+    echo "Installing libraries on Python ${VERSION}..."
+    pyenv global ${VERSION}
+    pip install -U pip setuptools
+    pip install "Cython==${CYTHON_VERSION}" wheel auditwheel
+done
+pyenv global system

--- a/dist_config.py
+++ b/dist_config.py
@@ -206,6 +206,27 @@ WHEEL_LINUX_CONFIGS = {
         'verify_image': 'nvidia/cuda:10.2-devel-{system}',
         'verify_systems': ['ubuntu16.04'],
     },
+    '11.0': {
+        # Starting in CUDA 11.0, cuDNN is no longer bundled.
+        'name': 'cupy-cuda110',
+        # TODO(kmaehashi): Use the official image when released.
+        'image': 'kmaehashi/cuda11-centos7:11.0-cudnn8-devel-centos7',
+        'libs': [
+            '/usr/local/cuda/lib64/libnccl.so.2',  # NCCL v2
+        ],
+        'includes': [],
+        'nccl': {
+            'type': 'v2-tar',
+            'files': [
+                'nccl_2.7.8-1+cuda11.0_x86_64.txz',
+            ],
+        },
+
+        # Note: Using image with cuDNN 8 preinstalled.
+        'verify_image': 'nvidia/cuda:11.0-cudnn8-runtime-{system}',
+        'verify_systems': ['ubuntu18.04'],
+    },
+
 }
 
 
@@ -272,6 +293,14 @@ WHEEL_WINDOWS_CONFIGS = {
         ],
         'cudart_lib': 'cudart64_102',
         'check_version': lambda x: 10020 <= x < 10030,
+    },
+    '11.0': {
+        'name': 'cupy-cuda110',
+        'libs': [
+            'nvToolsExt64_1.dll',  # NVIDIA Tools Extension Library
+        ],
+        'cudart_lib': 'cudart64_110',
+        'check_version': lambda x: 11000 <= x < 11010,
     },
 }
 

--- a/dist_config.py
+++ b/dist_config.py
@@ -322,6 +322,7 @@ SDIST_LONG_DESCRIPTION = _long_description_header + '''\
 This package (``cupy``) is a source distribution.
 For most users, use of pre-build wheel distributions are recommended:
 
+- `cupy-cuda110 <https://pypi.org/project/cupy-cuda110/>`_ (for CUDA 11.0)
 - `cupy-cuda102 <https://pypi.org/project/cupy-cuda102/>`_ (for CUDA 10.2)
 - `cupy-cuda101 <https://pypi.org/project/cupy-cuda101/>`_ (for CUDA 10.1)
 - `cupy-cuda100 <https://pypi.org/project/cupy-cuda100/>`_ (for CUDA 10.0)

--- a/dist_config.py
+++ b/dist_config.py
@@ -352,7 +352,7 @@ If you want to build CuPy from `source distribution <https://pypi.python.org/pyp
 # - `requires`: a list of required packages; this is needed as some older
 #               NumPy does not support newer Python.
 WHEEL_PYTHON_VERSIONS = {
-    '3.5.1': {
+    '3.5.3': {
         'python_tag': 'cp35',
         'abi_tag': 'cp35m',
         'requires': [],

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -26,8 +26,9 @@ ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 ARG python_versions
 RUN for VERSION in ${python_versions}; do \
       echo "Installing Python ${VERSION}..." && \
-      pyenv install ${VERSION}; \
-    done;
+      pyenv install ${VERSION} & \
+    done && \
+    wait
 
 # Install Python libraries.
 RUN for VERSION in ${python_versions}; do \


### PR DESCRIPTION
~Depends on #46.~ (merged)

This adds support for CUDA 11.0.
Note that CUDA 11.0 build uses CentOS 7 instead of CentOS 6, because C6 support has been dropped in CUDA 11.0.

- CUDA 11 build uses `kmaehashi/cuda11-centos7:11.0-cudnn8-devel-centos7` image, which is generated by https://github.com/kmaehashi/cuda11-centos7-docker.
  NVIDIA provides [Dockerfiles](https://gitlab.com/nvidia/container-images/cuda/-/tree/master/dist/11.0/centos7-x86_64) but does not provide images yet.
- cuDNN is now downloaded from NVIDIA.
- Fixed builder Docker images to use separate script to install Python/devtoolset.
  This is needed because we need to support both CentOS 6 (CUDA 10.2 or earlier) and CentOS 7 (CUDA 11.0+) builds.
- Use Python 3.5.3 instead of 3.5.1 to support OpenSSL 1.1.0, which is needed for CentOS 7.
- `builder` and `verifier` now builds Python concurrently. This improves performance.