### PR TITLE
Fixes for Windows wheel build

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -26,7 +26,7 @@ configs {
     time_limit {
       seconds: 3000
     }
-    command: ".pfnci\\wheel-windows\\main.bat 3.8.0 10.2 origin/master"
+    command: ".pfnci\\wheel-windows\\main.bat 3.8.0 10.2 master"
   }
 }
 configs {
@@ -42,6 +42,6 @@ configs {
     time_limit {
       seconds: 3000
     }
-    command: ".pfnci\\wheel-windows\\main.bat 3.8.0 10.2 origin/master"
+    command: ".pfnci\\wheel-windows\\main.bat 3.8.0 10.2 master"
   }
 }

--- a/.pfnci/wheel-windows/install_cudnn.ps1
+++ b/.pfnci/wheel-windows/install_cudnn.ps1
@@ -25,7 +25,7 @@ switch ($cuda) {
     "8.0" {
         $cuda_path = $Env:CUDA_PATH_V8_0
         $cudnn_version = "7.1.3"
-        $cudnn_archive = "cudnn-8.0-windows10-x64-v7.1-ga.zip"
+        $cudnn_archive = "cudnn-8.0-windows10-x64-v7.1.zip"
     }
     "9.0" {
         $cuda_path = $Env:CUDA_PATH_V9_0
@@ -67,6 +67,8 @@ switch ($cuda) {
     }
 }
 
-curl.exe -LO "https://developer.download.nvidia.com/compute/redist/cudnn/v${cudnn_version}/${cudnn_archive}"
+$url = "https://developer.download.nvidia.com/compute/redist/cudnn/v${cudnn_version}/${cudnn_archive}"
+echo "Downloading ${url}..."
+curl.exe -LO "${url}"
 
 install_cudnn $cudnn_archive $cuda_path

--- a/.pfnci/wheel-windows/install_cudnn.ps1
+++ b/.pfnci/wheel-windows/install_cudnn.ps1
@@ -5,6 +5,11 @@ Param(
 $ErrorActionPreference = "Stop"
 
 function install_cudnn([String]$cudnn_zip, [String]$cuda_root) {
+  echo "Uninstalling existing cuDNN installation from ${cuda_root}"
+  Remove-Item -Force -Verbose ${cuda_root}\bin\cudnn*.dll
+  Remove-Item -Force -Verbose ${cuda_root}\include\cudnn*.h
+  Remove-Item -Force -Verbose ${cuda_root}\lib\x64\cudnn*.lib
+
   echo "Installing ${cudnn_zip} to ${cuda_root}..."
   Remove-Item -Recurse -Force -ErrorAction:SilentlyContinue tmp_cudnn
   Expand-Archive -Path ${cudnn_zip} -DestinationPath tmp_cudnn
@@ -13,7 +18,7 @@ function install_cudnn([String]$cudnn_zip, [String]$cuda_root) {
   Move-Item -Force cuda\include\* ${cuda_root}\include
   Move-Item -Force cuda\lib\x64\* ${cuda_root}\lib\x64
   Pop-Location
-  Remove-Item -Recurse -Force -ErrorAction:SilentlyContinue tmp_cudnn
+  Remove-Item -Recurse -Force tmp_cudnn
 }
 
 switch ($cuda) {
@@ -62,6 +67,6 @@ switch ($cuda) {
     }
 }
 
-curl -LO "https://developer.download.nvidia.com/compute/redist/cudnn/v${cudnn_version}/${cudnn_archive}"
+curl.exe -LO "https://developer.download.nvidia.com/compute/redist/cudnn/v${cudnn_version}/${cudnn_archive}"
 
 install_cudnn $cudnn_archive $cuda_path

--- a/.pfnci/wheel-windows/main.bat
+++ b/.pfnci/wheel-windows/main.bat
@@ -3,16 +3,17 @@
 set PYTHON=%1
 set CUDA=%2
 set BRANCH=%3
+set JOB_GROUP=%4
 
 :: Install cuDNN
 PowerShell .pfnci\wheel-windows\install_cudnn.ps1 -cuda %CUDA% || exit 1
 
 :: Clone CuPy
 git clone --recursive https://github.com/cupy/cupy.git cupy || exit 1
-git -C cupy checkout %BRANCH% || exit 1
+git -C cupy checkout origin/%BRANCH% || exit 1
 
 :: Build
 PowerShell .pfnci\wheel-windows\build.ps1 -python %PYTHON% -cuda %CUDA% || exit 1
 
 :: Upload wheel to GCS
-gsutil -m cp cupy*.whl gs://tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/%FLEXCI_JOB_ID%_%PYTHON%_%CUDA%/ || exit 1
+gsutil -m cp cupy*.whl gs://tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/%JOB_GROUP%_%BRANCH%/%FLEXCI_JOB_ID%_%PYTHON%_%CUDA%/ || exit 1

--- a/.pfnci/wheel-windows/main.bat
+++ b/.pfnci/wheel-windows/main.bat
@@ -5,14 +5,14 @@ set CUDA=%2
 set BRANCH=%3
 
 :: Install cuDNN
-PowerShell .pfnci\wheel-windows\install_cudnn.ps1 -cuda %CUDA%
+PowerShell .pfnci\wheel-windows\install_cudnn.ps1 -cuda %CUDA% || exit 1
 
 :: Clone CuPy
-git clone --recursive https://github.com/cupy/cupy.git cupy
-git -C cupy checkout %BRANCH%
+git clone --recursive https://github.com/cupy/cupy.git cupy || exit 1
+git -C cupy checkout %BRANCH% || exit 1
 
 :: Build
-PowerShell .pfnci\wheel-windows\build.ps1 -python %PYTHON% -cuda %CUDA%
+PowerShell .pfnci\wheel-windows\build.ps1 -python %PYTHON% -cuda %CUDA% || exit 1
 
 :: Upload wheel to GCS
-gsutil -m cp cupy*.whl gs://tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/%FLEXCI_JOB_ID%_%PYTHON%_%CUDA%/
+gsutil -m cp cupy*.whl gs://tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/%FLEXCI_JOB_ID%_%PYTHON%_%CUDA%/ || exit 1

--- a/.pfnci/wheel-windows/submit.sh
+++ b/.pfnci/wheel-windows/submit.sh
@@ -8,15 +8,15 @@ echo "JOB_GROUP = ${JOB_GROUP}"
 echo "URL = https://console.cloud.google.com/storage/browser/tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/${JOB_GROUP}/"
 
 BRANCH="v7"
-for PYTHON in 3.6.0 3.7.0 3.8.0; do
-  for CUDA in 8.0 9.0 9.1 9.2 10.0 10.1 10.2 11.0; do
+for CUDA in 8.0 9.0 9.1 9.2 10.0 10.1 10.2 11.0; do
+  for PYTHON in 3.6.0 3.7.0 3.8.0; do
     imosci --project=cupy-wheel-win run ".pfnci\\wheel-windows\\main.bat ${PYTHON} ${CUDA} ${BRANCH} ${JOB_GROUP}"
   done
 done
 
 BRANCH="master"
-for PYTHON in 3.6.0 3.7.0 3.8.0; do
-  for CUDA in 9.0 9.2 10.0 10.1 10.2 11.0; do
+for CUDA in 9.0 9.2 10.0 10.1 10.2 11.0; do
+  for PYTHON in 3.6.0 3.7.0 3.8.0; do
     imosci --project=cupy-wheel-win run ".pfnci\\wheel-windows\\main.bat ${PYTHON} ${CUDA} ${BRANCH} ${JOB_GROUP}"
   done
 done

--- a/.pfnci/wheel-windows/submit.sh
+++ b/.pfnci/wheel-windows/submit.sh
@@ -1,10 +1,22 @@
 #!/bin/sh -uex
 
 # Submit as FlexCI jobs
+
+JOB_GROUP="$(date +"%F_%T")"
+
+echo "JOB_GROUP = ${JOB_GROUP}"
+echo "URL = https://console.cloud.google.com/storage/browser/tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/${JOB_GROUP}/"
+
+BRANCH="v7"
 for PYTHON in 3.6.0 3.7.0 3.8.0; do
-  for CUDA in 8.0 9.0 9.1 9.2 10.0 10.1 10.2; do
-    for BRANCH in origin/master origin/v7; do
-      imosci --project=cupy-wheel-win run ".pfnci\\wheel-windows\\main.bat ${PYTHON} ${CUDA} ${BRANCH}"
-    done
+  for CUDA in 8.0 9.0 9.1 9.2 10.0 10.1 10.2 11.0; do
+    imosci --project=cupy-wheel-win run ".pfnci\\wheel-windows\\main.bat ${PYTHON} ${CUDA} ${BRANCH} ${JOB_GROUP}"
+  done
+done
+
+BRANCH="master"
+for PYTHON in 3.6.0 3.7.0 3.8.0; do
+  for CUDA in 9.0 9.2 10.0 10.1 10.2 11.0; do
+    imosci --project=cupy-wheel-win run ".pfnci\\wheel-windows\\main.bat ${PYTHON} ${CUDA} ${BRANCH} ${JOB_GROUP}"
   done
 done


### PR DESCRIPTION
* Remove existing cuDNN installation first to make sure that our version is used
* Fix typo in cuDNN filename for CUDA 8.0
* Show cuDNN download URL
* Make sure to fail (exit 1) when some command failed
* Dig a directory to collect wheels easier
