### PR TITLE
[DO NOT MERGE] Wheel Builder for v7.8.0

### DIFF
--- a/.pfnci/wheel-windows/submit.sh
+++ b/.pfnci/wheel-windows/submit.sh
@@ -13,6 +13,7 @@ for CUDA in 8.0 9.0 9.1 9.2 10.0 10.1 10.2 11.0; do
     imosci --project=cupy-wheel-win run ".pfnci\\wheel-windows\\main.bat ${PYTHON} ${CUDA} ${BRANCH} ${JOB_GROUP}"
   done
 done
+exit
 
 BRANCH="master"
 for CUDA in 9.0 9.2 10.0 10.1 10.2 11.0; do

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-if [ -f /opt/rh/devtoolset-6/enable ]; then
-    # CentOS 6
-    source /opt/rh/devtoolset-6/enable
-else
+if [ -f /opt/rh/devtoolset-7/enable ]; then
     # CentOS 7 (CUDA 11.0+)
     source /opt/rh/devtoolset-7/enable
 fi

--- a/builder/setup_devtoolset.sh
+++ b/builder/setup_devtoolset.sh
@@ -1,15 +1,8 @@
 #!/bin/bash -uex
 
-yum install -y centos-release-scl
-
-if [ $(rpm --eval '%{rhel}') == 6 ]; then
-    # CentOS 6
-    perl -pi -e 's|^#baseurl=http://mirror.centos.org/centos/6/sclo/\$basearch/rh/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/6.8/sclo/\$basearch/rh/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    perl -pi -e 's|^mirrorlist=|#mirrorlist=|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    yum install -y devtoolset-6-gcc-c++
-else
-    # CentOS 7
+if rpm -qa | grep cuda-cudart-11-0; then
+    # CentOS 7 (CUDA 11.0)
+    yum install -y centos-release-scl
     yum install -y devtoolset-7-gcc-c++
+    yum clean all
 fi
-
-yum clean all


### PR DESCRIPTION
Depends on #52 and #53.

Enable gcc-6 or later only for CUDA 11.0.
This is because CUDA 8.0 (which will be dropped in CuPy v8) requires gcc-5 or earlier.