### PR TITLE
Add cupy-rocm-4-0 builder

### DIFF
--- a/build-rocm.sh
+++ b/build-rocm.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -uex
+
+CUDA="${1}"
+PYTHON="${2}"
+
+DIST_OPTIONS="--target wheel-linux --python ${PYTHON} --cuda ${CUDA}"
+eval $(./get_dist_info.py ${DIST_OPTIONS} --source cupy)
+
+./dist.py --action build  ${DIST_OPTIONS} --source cupy --output .
+./dist.py --action verify ${DIST_OPTIONS} --dist ${DIST_FILE_NAME} --test release-tests/common

--- a/build-rocm.sh
+++ b/build-rocm.sh
@@ -11,4 +11,4 @@ DIST_OPTIONS="--target wheel-linux --python ${PYTHON} --cuda ${CUDA}"
 eval $(./get_dist_info.py ${DIST_OPTIONS} --source cupy)
 
 ./dist.py --action build  ${DIST_OPTIONS} --source cupy --output .
-./dist.py --action verify ${DIST_OPTIONS} --dist ${DIST_FILE_NAME} --test release-tests/common
+./dist.py --action verify ${DIST_OPTIONS} --dist ${DIST_FILE_NAME} --test release-tests/common --test release-tests/nccl

--- a/build-rocm.sh
+++ b/build-rocm.sh
@@ -3,6 +3,10 @@
 CUDA="${1}"
 PYTHON="${2}"
 
+if [ "${HCC_AMDGPU_TARGET:-}" = "" ]; then
+    echo "*** HCC_AMDGPU_TARGET is not set, verification will fail"
+fi
+
 DIST_OPTIONS="--target wheel-linux --python ${PYTHON} --cuda ${CUDA}"
 eval $(./get_dist_info.py ${DIST_OPTIONS} --source cupy)
 

--- a/build-rocm.sh
+++ b/build-rocm.sh
@@ -3,9 +3,9 @@
 CUDA="${1}"
 PYTHON="${2}"
 
-if [ "${HCC_AMDGPU_TARGET:-}" = "" ]; then
-    echo "*** HCC_AMDGPU_TARGET is not set, verification will fail"
-fi
+# https://github.com/RadeonOpenCompute/ROCm#hardware-and-software-support
+# https://rocmdocs.amd.com/en/latest/ROCm_Compiler_SDK/ROCm-Native-ISA.html#processors
+export HCC_AMDGPU_TARGET=gfx801,gfx802,gfx803,gfx900,gfx906,gfx908,gfx1010,gfx1011,gfx1012
 
 DIST_OPTIONS="--target wheel-linux --python ${PYTHON} --cuda ${CUDA}"
 eval $(./get_dist_info.py ${DIST_OPTIONS} --source cupy)

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ case ${CUDA} in
     ;;
 esac
 
-VERIFY_ARGS="--test release-tests/common --test release-tests/cudnn"
+VERIFY_ARGS="--test release-tests/common --test release-tests/sparse --test release-tests/cudnn"
 
 if [ "${CUDA}" = "sdist" ]; then
   VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/pkg_sdist"

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -34,9 +34,10 @@ RUN ( [ ! -d /cudnn/cuda/lib64 ]   || mv /cudnn/cuda/lib64/*   /usr/local/cuda/l
     ldconfig
 
 # Install additional dependencies for ROCm.
-RUN [ -d /opt/rocm ] && \
-    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 rccl4.0.1 && \
-    yum clean all
+RUN [ ! -d /opt/rocm ] || ( \
+        yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 rccl4.0.1 && \
+        yum clean all \
+    )
 
 # Install requirements for agents.
 RUN yum -y install python-setuptools && \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -33,6 +33,11 @@ RUN ( [ ! -d /cudnn/cuda/lib64 ]   || mv /cudnn/cuda/lib64/*   /usr/local/cuda/l
     ( [ ! -d /cudnn/cuda/include ] || mv /cudnn/cuda/include/* /usr/local/cuda/include ) && \
     ldconfig
 
+# Install additional dependencies for ROCm.
+RUN [ -d /opt/rocm ] && \
+    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 && \
+    yum clean all
+
 # Install requirements for agents.
 RUN yum -y install python-setuptools && \
     yum clean all

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -35,7 +35,7 @@ RUN ( [ ! -d /cudnn/cuda/lib64 ]   || mv /cudnn/cuda/lib64/*   /usr/local/cuda/l
 
 # Install additional dependencies for ROCm.
 RUN [ -d /opt/rocm ] && \
-    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 && \
+    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 rccl4.0.1 && \
     yum clean all
 
 # Install requirements for agents.

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -12,11 +12,6 @@ fi
 # ROCm
 if [ -d /opt/rocm ]; then
   export ROCM_HOME="/opt/rocm"
-  export PATH="${ROCM_HOME}/bin:${PATH}"
-  export LD_LIBRARY_PATH="${ROCM_HOME}/lib:${LD_LIBRARY_PATH}"
-  export CPATH="${ROCM_HOME}/include:${CPATH}"
-  export LDFLAGS="-L${ROCM_HOME}/lib ${LDFLAGS}"
-
   export CUPY_INSTALL_USE_HIP=1
 fi
 

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -18,8 +18,6 @@ if [ -d /opt/rocm ]; then
   export LDFLAGS="-L${ROCM_HOME}/lib ${LDFLAGS}"
 
   export CUPY_INSTALL_USE_HIP=1
-  export HCC_AMDGPU_TARGET=gfx803
-  export __HIP_PLATFORM_HCC__
 fi
 
 "$@"

--- a/builder/build-wrapper
+++ b/builder/build-wrapper
@@ -1,11 +1,25 @@
 #!/bin/bash
 
+# devtoolset
 if [ -f /opt/rh/devtoolset-6/enable ]; then
     # CentOS 6
     source /opt/rh/devtoolset-6/enable
 else
     # CentOS 7 (CUDA 11.0+)
     source /opt/rh/devtoolset-7/enable
+fi
+
+# ROCm
+if [ -d /opt/rocm ]; then
+  export ROCM_HOME="/opt/rocm"
+  export PATH="${ROCM_HOME}/bin:${PATH}"
+  export LD_LIBRARY_PATH="${ROCM_HOME}/lib:${LD_LIBRARY_PATH}"
+  export CPATH="${ROCM_HOME}/include:${CPATH}"
+  export LDFLAGS="-L${ROCM_HOME}/lib ${LDFLAGS}"
+
+  export CUPY_INSTALL_USE_HIP=1
+  export HCC_AMDGPU_TARGET=gfx803
+  export __HIP_PLATFORM_HCC__
 fi
 
 "$@"

--- a/dist.py
+++ b/dist.py
@@ -273,8 +273,10 @@ class Controller(object):
             nccl_config = WHEEL_LINUX_CONFIGS[cuda_version]['nccl']
 
             # cuDNN
-            cudnn_version, cudnn_assets = get_cudnn_record(
-                cuda_version, 'Linux')
+            #cudnn_version, cudnn_assets = get_cudnn_record(
+            #    cuda_version, 'Linux')
+            cudnn_version = None
+            cudnn_assets = None
 
             # Rename wheels to manylinux1.
             asset_name = wheel_name(
@@ -383,13 +385,16 @@ class Controller(object):
             # Create a wheel metadata file for preload.
             if target == 'wheel-linux':
                 log('Writing wheel metadata')
-                wheel_metadata = {
-                    'cuda': cuda_version,
-                    'cudnn': {
-                        'version': cudnn_version,
-                        'filename': cudnn_assets['filename'],
+                if cudnn_version is not None:
+                    wheel_metadata = {
+                        'cuda': cuda_version,
+                        'cudnn': {
+                            'version': cudnn_version,
+                            'filename': cudnn_assets['filename'],
+                        }
                     }
-                }
+                else:
+                    wheel_metadata = {}
                 with open('{}/_wheel.json'.format(workdir), 'w') as f:
                     json.dump(wheel_metadata, f)
 

--- a/dist.py
+++ b/dist.py
@@ -388,16 +388,14 @@ class Controller(object):
             # Create a wheel metadata file for preload.
             if target == 'wheel-linux':
                 log('Writing wheel metadata')
+                wheel_metadata = {
+                    'cuda': cuda_version,
+                }
                 if cudnn_version is not None:
-                    wheel_metadata = {
-                        'cuda': cuda_version,
-                        'cudnn': {
-                            'version': cudnn_version,
-                            'filename': cudnn_assets['filename'],
-                        }
+                    wheel_metadata['cudnn'] = {
+                        'version': cudnn_version,
+                        'filename': cudnn_assets['filename'],
                     }
-                else:
-                    wheel_metadata = {}
                 with open('{}/_wheel.json'.format(workdir), 'w') as f:
                     json.dump(wheel_metadata, f)
 

--- a/dist.py
+++ b/dist.py
@@ -247,6 +247,7 @@ class Controller(object):
                 '--device=/dev/kfd', '--device=/dev/dri',
                 '--security-opt', 'seccomp=unconfined',
                 '--group-add', 'video',
+                '--env', 'HCC_AMDGPU_TARGET',
             ]
         else:
             assert False

--- a/dist.py
+++ b/dist.py
@@ -265,18 +265,24 @@ class Controller(object):
                     source, version, cuda_version, python_version))
             action = 'bdist_wheel'
             image_tag = 'cupy-builder-{}'.format(cuda_version)
+            kind = WHEEL_LINUX_CONFIGS[cuda_version][kind]
             base_image = WHEEL_LINUX_CONFIGS[cuda_version]['image']
             package_name = WHEEL_LINUX_CONFIGS[cuda_version]['name']
             long_description = WHEEL_LONG_DESCRIPTION.format(cuda=cuda_version)
 
-            # NCCL
-            nccl_config = WHEEL_LINUX_CONFIGS[cuda_version]['nccl']
+            if kind == 'cuda':
+                # NCCL
+                nccl_config = WHEEL_LINUX_CONFIGS[cuda_version]['nccl']
 
-            # cuDNN
-            #cudnn_version, cudnn_assets = get_cudnn_record(
-            #    cuda_version, 'Linux')
-            cudnn_version = None
-            cudnn_assets = None
+                # cuDNN
+                cudnn_version, cudnn_assets = get_cudnn_record(
+                    cuda_version, 'Linux')
+            elif kind == 'rocm':
+                nccl_config = None
+                cudnn_version = None
+                cudnn_assets = None
+            else:
+                assert False
 
             # Rename wheels to manylinux1.
             asset_name = wheel_name(

--- a/dist.py
+++ b/dist.py
@@ -637,7 +637,7 @@ class Controller(object):
 
             # Copy verifier directory to working directory.
             docker_ctx = '{}/verifier'.format(workdir)
-            log('Copying verifier directory to: '.format(docker_ctx))
+            log('Copying verifier directory to: {}'.format(docker_ctx))
             shutil.copytree('verifier/', docker_ctx)
 
             # Extract NCCL archive.

--- a/dist.py
+++ b/dist.py
@@ -216,7 +216,7 @@ class Controller(object):
         if 'rhel' in base_image or 'centos' in base_image:
             log('Using RHEL Dockerfile template')
             template = 'rhel'
-        elif 'ubuntu' in base_image:
+        elif 'ubuntu' in base_image or 'rocm' in base_image:
             log('Using Debian Dockerfile template')
             template = 'debian'
         else:

--- a/dist.py
+++ b/dist.py
@@ -254,9 +254,6 @@ class Controller(object):
 
         version = get_version_from_source_tree(source)
 
-        if nccl_assets is None:
-            raise RuntimeError('NCCL assets must be specified for Linux')
-
         if target == 'wheel-linux':
             assert cuda_version is not None
             log(
@@ -265,7 +262,7 @@ class Controller(object):
                     source, version, cuda_version, python_version))
             action = 'bdist_wheel'
             image_tag = 'cupy-builder-{}'.format(cuda_version)
-            kind = WHEEL_LINUX_CONFIGS[cuda_version][kind]
+            kind = WHEEL_LINUX_CONFIGS[cuda_version]['kind']
             base_image = WHEEL_LINUX_CONFIGS[cuda_version]['image']
             package_name = WHEEL_LINUX_CONFIGS[cuda_version]['name']
             long_description = WHEEL_LONG_DESCRIPTION.format(cuda=cuda_version)

--- a/dist_config.py
+++ b/dist_config.py
@@ -169,6 +169,15 @@ WHEEL_LINUX_CONFIGS = {
         'verify_systems': ['ubuntu18.04'],
         'verify_preloads': ['cudnn'],
     },
+    'rocm-3.9': {
+        'name': 'cupy-rocm',
+        'image': 'rocm/dev-centos-7:3.9',
+        'libs': [],
+        'includes': [],
+        'nccl': None,
+        'verify_image': 'rocm/rocm-terminal:3.9',
+        'verify_systems': [''],
+    }
 }
 
 

--- a/dist_config.py
+++ b/dist_config.py
@@ -177,7 +177,7 @@ WHEEL_LINUX_CONFIGS = {
         'verify_preloads': ['cudnn'],
     },
     'rocm-4.0': {
-        'name': 'cupy-rocm',  # cupy-rocm-4-0
+        'name': 'cupy-rocm-4-0',
         'kind': 'rocm',
         'image': 'rocm/dev-centos-7:4.0.1',
         'libs': [],

--- a/dist_config.py
+++ b/dist_config.py
@@ -184,7 +184,8 @@ WHEEL_LINUX_CONFIGS = {
         'includes': [],
         'nccl': None,
         'verify_image': 'rocm/rocm-terminal:4.0',
-        'verify_systems': [''],
+        'verify_systems': ['default'],
+        'verify_preloads': [],
     }
 }
 

--- a/dist_config.py
+++ b/dist_config.py
@@ -177,7 +177,7 @@ WHEEL_LINUX_CONFIGS = {
         'verify_preloads': ['cudnn'],
     },
     'rocm-4.0': {
-        'name': 'cupy-rocm-4-0',
+        'name': 'cupy-rocm',  # cupy-rocm-4-0
         'kind': 'rocm',
         'image': 'rocm/dev-centos-7:4.0.1',
         'libs': [],

--- a/dist_config.py
+++ b/dist_config.py
@@ -31,6 +31,7 @@ SDIST_CONFIG = {
 WHEEL_LINUX_CONFIGS = {
     '9.0': {
         'name': 'cupy-cuda90',
+        'kind': 'cuda',
         'image': 'nvidia/cuda:9.0-devel-centos6',
         'libs': [
             '/usr/local/cuda/lib64/libcudnn.so.7',  # cuDNN v7
@@ -53,6 +54,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     '9.2': {
         'name': 'cupy-cuda92',
+        'kind': 'cuda',
         'image': 'nvidia/cuda:9.2-devel-centos6',
         'libs': [
             '/usr/local/cuda/lib64/libcudnn.so.7',  # cuDNN v7
@@ -74,6 +76,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     '10.0': {
         'name': 'cupy-cuda100',
+        'kind': 'cuda',
         'image': 'nvidia/cuda:10.0-devel-centos6',
         'libs': [
             '/usr/local/cuda/lib64/libcudnn.so.7',  # cuDNN v7
@@ -94,6 +97,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     '10.1': {
         'name': 'cupy-cuda101',
+        'kind': 'cuda',
         'image': 'nvidia/cuda:10.1-devel-centos6',
         'libs': [
             '/usr/local/cuda/lib64/libnccl.so.2',  # NCCL v2
@@ -113,6 +117,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     '10.2': {
         'name': 'cupy-cuda102',
+        'kind': 'cuda',
         'image': 'nvidia/cuda:10.2-devel-centos6',
         'libs': [
             '/usr/local/cuda/lib64/libnccl.so.2',  # NCCL v2
@@ -132,6 +137,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     '11.0': {
         'name': 'cupy-cuda110',
+        'kind': 'cuda',
         # TODO(kmaehashi): Use the official image when released.
         'image': 'kmaehashi/cuda11-centos7:11.0-devel-centos7',
         'libs': [
@@ -152,6 +158,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     '11.1': {
         'name': 'cupy-cuda111',
+        'kind': 'cuda',
         'image': 'nvidia/cuda:11.1-devel-centos7',
         'libs': [
             '/usr/local/cuda/lib64/libnccl.so.2',  # NCCL v2
@@ -171,6 +178,7 @@ WHEEL_LINUX_CONFIGS = {
     },
     'rocm-4.0': {
         'name': 'cupy-rocm-4-0',
+        'kind': 'rocm',
         'image': 'rocm/dev-centos-7:4.0.1',
         'libs': [],
         'includes': [],

--- a/dist_config.py
+++ b/dist_config.py
@@ -169,13 +169,13 @@ WHEEL_LINUX_CONFIGS = {
         'verify_systems': ['ubuntu18.04'],
         'verify_preloads': ['cudnn'],
     },
-    'rocm-3.9': {
-        'name': 'cupy-rocm',
-        'image': 'rocm/dev-centos-7:3.9',
+    'rocm-4.0': {
+        'name': 'cupy-rocm-4-0',
+        'image': 'rocm/dev-centos-7:4.0.1',
         'libs': [],
         'includes': [],
         'nccl': None,
-        'verify_image': 'rocm/rocm-terminal:3.9',
+        'verify_image': 'rocm/rocm-terminal:4.0',
         'verify_systems': [''],
     }
 }

--- a/release-tests/common/test_basic.py
+++ b/release-tests/common/test_basic.py
@@ -35,11 +35,3 @@ class TestCuRand(unittest.TestCase):
     def test_randn(self):
         rs = cupy.random.get_random_state()
         rs.randn(10)
-
-
-class TestCuSparse(unittest.TestCase):
-    def test_csr(self):
-        m = cupy.array([[0, 1, 0, 2],
-                        [0, 0, 0, 0],
-                        [0, 0, 3, 0]], dtype=cupy.float32)
-        cupyx.scipy.sparse.csr_matrix(m)

--- a/release-tests/common/test_basic.py
+++ b/release-tests/common/test_basic.py
@@ -1,7 +1,6 @@
 import unittest
 
 import cupy
-import cupyx
 
 
 class TestBasic(unittest.TestCase):

--- a/release-tests/sparse/test_basic.py
+++ b/release-tests/sparse/test_basic.py
@@ -1,0 +1,13 @@
+import unittest
+
+import cupy
+import cupyx
+
+
+class TestCuSparse(unittest.TestCase):
+    # Separated from common tests as ROCm build does not support cuSPARSE yet.
+    def test_csr(self):
+        m = cupy.array([[0, 1, 0, 2],
+                        [0, 0, 0, 0],
+                        [0, 0, 3, 0]], dtype=cupy.float32)
+        cupyx.scipy.sparse.csr_matrix(m)

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -51,7 +51,7 @@ RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
 RUN [ -d /opt/rocm ] && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y update && \
-    apt-get -y install hipcub hipblas rocrand rocfft rocsolver && \
+    apt-get -y install hipcub hipblas rocrand rocfft rocsolver rccl && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Use /tmp as a temporary home to install package.

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -48,7 +48,7 @@ RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
     ldconfig
 
 # Install additional dependencies for ROCm.
-RUN [ -d /opt/rocm ] || ( \
+RUN [ ! -d /opt/rocm ] || ( \
         export DEBIAN_FRONTEND=noninteractive && \
         apt-get -y update && \
         apt-get -y install hipcub hipblas rocrand rocfft rocsolver rccl && \

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -48,11 +48,12 @@ RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
     ldconfig
 
 # Install additional dependencies for ROCm.
-RUN [ -d /opt/rocm ] && \
-    export DEBIAN_FRONTEND=noninteractive && \
-    apt-get -y update && \
-    apt-get -y install hipcub hipblas rocrand rocfft rocsolver rccl && \
-    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+RUN [ -d /opt/rocm ] || ( \
+        export DEBIAN_FRONTEND=noninteractive && \
+        apt-get -y update && \
+        apt-get -y install hipcub hipblas rocrand rocfft rocsolver rccl && \
+        rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+    )
 
 # Use /tmp as a temporary home to install package.
 ENV HOME /tmp

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -47,6 +47,13 @@ RUN ( [ ! -d /nccl/lib ]     || mv /nccl/lib/*     /usr/local/cuda/lib64 ) && \
     ( [ ! -d /nccl/include ] || mv /nccl/include/* /usr/local/cuda/include ) && \
     ldconfig
 
+# Install additional dependencies for ROCm.
+RUN [ -d /opt/rocm ] && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
+    apt-get -y install hipcub hipblas rocrand rocfft rocsolver && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 # Use /tmp as a temporary home to install package.
 ENV HOME /tmp
 

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -1,6 +1,7 @@
 ARG base_image
 FROM ${base_image}
 
+USER root
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y update && \
     apt-get -y install gcc g++ make patch git && \

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -1,6 +1,7 @@
 ARG base_image
 FROM ${base_image}
 
+USER root
 RUN sed -ie 's|#baseurl=http://mirror.centos.org/centos/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/centos/|g' /etc/yum.repos.d/CentOS-Base.repo
 RUN yum -y update && \
     yum -y install gcc gcc-c++ make patch git && \

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -31,9 +31,10 @@ RUN for VERSION in ${python_versions}; do \
     pyenv global system
 
 # Install additional dependencies for ROCm.
-RUN [ -d /opt/rocm ] && \
-    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 rccl4.0.1 && \
-    yum clean all
+RUN [ ! -d /opt/rocm ] || ( \
+        yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 rccl4.0.1 && \
+        yum clean all \
+    )
 
 # Install requirements for agents.
 RUN yum -y install python-setuptools && yum clean all

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -30,6 +30,11 @@ RUN for VERSION in ${python_versions}; do \
     done && \
     pyenv global system
 
+# Install additional dependencies for ROCm.
+RUN [ -d /opt/rocm ] && \
+    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 && \
+    yum clean all
+
 # Install requirements for agents.
 RUN yum -y install python-setuptools && yum clean all
 RUN easy_install argparse

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -32,7 +32,7 @@ RUN for VERSION in ${python_versions}; do \
 
 # Install additional dependencies for ROCm.
 RUN [ -d /opt/rocm ] && \
-    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 && \
+    yum -y install hipcub4.0.1 hipblas4.0.1 rocrand4.0.1 rocfft4.0.1 rocsolver4.0.1 rccl4.0.1 && \
     yum clean all
 
 # Install requirements for agents.


### PR DESCRIPTION
Run `./build-rocm.sh rocm-4.0 3.8.0` to build packages.

Blocked by https://github.com/cupy/cupy/pull/4717