### PR TITLE
Check version before starting a build

### DIFF
--- a/dist.py
+++ b/dist.py
@@ -219,17 +219,20 @@ class Controller(object):
         ] + agent_args
         run_command(*command)
 
+    def _ensure_compatible_branch(self, version):
+        if version.split('.')[0] != CUPY_MAJOR_VERSION:
+            raise RuntimeError(
+                'Version mismatch. cupy-release-tools is for CuPy v{} '
+                'but your source tree is CuPy v{}.'.format(
+                    CUPY_MAJOR_VERSION, version))
+
     def build_linux(
             self, target, cuda_version, python_version,
             source, output):
         """Build a single wheel distribution for Linux."""
 
         version = get_version_from_source_tree(source)
-        if version.split('.')[0] != CUPY_MAJOR_VERSION:
-            raise RuntimeError(
-                'Version mismatch. cupy-release-tools is for CuPy v{} '
-                'but your source tree is CuPy v{}.'.format(
-                    CUPY_MAJOR_VERSION, version))
+        self._ensure_compatible_branch(version)
 
         if target == 'wheel-linux':
             assert cuda_version is not None
@@ -409,6 +412,7 @@ class Controller(object):
             raise ValueError('unknown target')
 
         version = get_version_from_source_tree(source)
+        self._ensure_compatible_branch(version)
 
         log(
             'Starting wheel-win build from {} '

--- a/dist.py
+++ b/dist.py
@@ -13,6 +13,7 @@ import time
 
 
 from dist_config import (
+    CUPY_MAJOR_VERSION,
     CYTHON_VERSION,
     SDIST_CONFIG,
     SDIST_LONG_DESCRIPTION,
@@ -224,6 +225,11 @@ class Controller(object):
         """Build a single wheel distribution for Linux."""
 
         version = get_version_from_source_tree(source)
+        if version.split('.')[0] != CUPY_MAJOR_VERSION:
+            raise RuntimeError(
+                'Version mismatch. cupy-release-tools is for CuPy v{} '
+                'but your source tree is CuPy v{}.'.format(
+                    CUPY_MAJOR_VERSION, version))
 
         if target == 'wheel-linux':
             assert cuda_version is not None

--- a/dist_config.py
+++ b/dist_config.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# CuPy major version supported by this tool.
+CUPY_MAJOR_VERSION = '9'
+
 # Cython version to cythonize the code.
 CYTHON_VERSION = '0.29.22'
 


### PR DESCRIPTION
Now that we have two branches in cupy-release-tools, FlexCI jobs must be submit from a branch that matches with the CuPy source tree.
It is an likely error to submit a job from wrong branch, so let's add a protection.