### PR TITLE
Tentatively pin verifier to use rocm-4.0

### DIFF
--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -44,6 +44,7 @@ RUN for VERSION in ${python_versions}; do \
 # Install additional dependencies for ROCm.
 RUN [ ! -d /opt/rocm ] || ( \
         export DEBIAN_FRONTEND=noninteractive && \
+        sed -ie 's|http://repo.radeon.com/rocm/apt/debian/|http://repo.radeon.com/rocm/apt/4.0/|' /etc/apt/sources.list.d/rocm.list && \
         apt-get -y update && \
         apt-get -y install hipblas hipsparse rocsparse rocrand rocthrust rocsolver rocfft hipcub rocprim rccl && \
         rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \


### PR DESCRIPTION
When running `apt install hipblas` (or other libraries) in `rocm/rocm-termianl:4.0` docker image, it tries to download the latest ROCm (currently 4.1) because apt repository url points to the latest release.

WIP: I'm now checking if verification work.