### PR TITLE
[v8] Fix log output format

### DIFF
--- a/dist.py
+++ b/dist.py
@@ -221,7 +221,7 @@ class Controller(object):
             template = 'debian'
         else:
             raise RuntimeError(
-                'cannot detect OS from image name: '.format(base_image))
+                'cannot detect OS from image name: {}'.format(base_image))
         shutil.copy2(
             '{}/Dockerfile.{}'.format(docker_ctx, template),
             '{}/Dockerfile'.format(docker_ctx))
@@ -373,7 +373,7 @@ class Controller(object):
 
             # Copy builder directory to working directory.
             docker_ctx = '{}/builder'.format(workdir)
-            log('Copying builder directory to: '.format(docker_ctx))
+            log('Copying builder directory to: {}'.format(docker_ctx))
             shutil.copytree('builder/', docker_ctx)
 
             # Extract NCCL archive.


### PR DESCRIPTION
This was fixed in master in https://github.com/cupy/cupy-release-tools/pull/79/commits/63c4a07a890cabd594a0fc05b26f47081535fbd1 should be backported to v8