### PR TITLE
fix nccl preload test version

### DIFF
--- a/release-tests/pkg_wheel/test_preload.py
+++ b/release-tests/pkg_wheel/test_preload.py
@@ -28,7 +28,11 @@ class TestPreload(unittest.TestCase):
             return
         preload_version = self._get_config()['nccl']['version']
         major, minor, patchlevel = (int(x) for x in preload_version.split('.'))
-        expected_version = major * 1000 + minor * 100 + patchlevel
+        major_mult = 1000
+        if major >= 2 and minor > 8:
+            # NCCL 2.9 shows version as 20908 instead of 2908
+            major_mult = 10000
+        expected_version = major * major_mult + minor * 100 + patchlevel
         assert libnccl.available
         assert libnccl.get_build_version() == expected_version
         assert libnccl.get_version() == expected_version

--- a/release-tests/pkg_wheel/test_preload.py
+++ b/release-tests/pkg_wheel/test_preload.py
@@ -29,7 +29,7 @@ class TestPreload(unittest.TestCase):
         preload_version = self._get_config()['nccl']['version']
         major, minor, patchlevel = (int(x) for x in preload_version.split('.'))
         major_mult = 1000
-        if major >= 2 and minor > 8:
+        if (2, 9) <= (major, minor):
             # NCCL 2.9 shows version as 20908 instead of 2908
             major_mult = 10000
         expected_version = major * major_mult + minor * 100 + patchlevel


### PR DESCRIPTION
With nccl 2.9 the version format changed...
```
nccl      : Yes (version 20908)
```
Previously

```
nccl      : Yes (version 2803)
```