### PR TITLE
Remove setuptools version restriction

### DIFF
--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -36,7 +36,7 @@ RUN for VERSION in ${python_versions}; do \
 RUN for VERSION in ${python_versions}; do \
       echo "Installing libraries on Python ${VERSION}..." && \
       pyenv global ${VERSION} && \
-      pip install -U pip 'setuptools<42' && \
+      pip install -U pip setuptools && \
       pip install pytest mock; \
       pip install numpy scipy; \
     done

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -25,7 +25,7 @@ RUN for VERSION in ${python_versions}; do \
 RUN for VERSION in ${python_versions}; do \
       echo "Installing libraries on Python ${VERSION}..." && \
       pyenv global ${VERSION} && \
-      pip install -U pip 'setuptools<42' && \
+      pip install -U pip setuptools && \
       pip install pytest mock; \
       pip install numpy scipy; \
     done


### PR DESCRIPTION
setuptools 41.x seems to have a bug that, during resolving `setup_requires` dependencies, pre-release versions are selected regardless of the version specified in the requirement.
As a result, sdist verification fails because Cython 3.0a7 (released on May 25th) is installed.

The setuptools version restriction was originally introduced as a workaround of this issue https://github.com/chainer/chainer-test/issues/565, but it seems now resolved.