### PR TITLE
Fix build issues of ROCm wheels

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -18,7 +18,6 @@ configs {
   value {
     requirement {
       cpu: 8
-      gpu: 1
       memory: 36
       disk: 30
     }

--- a/dist.py
+++ b/dist.py
@@ -210,12 +210,14 @@ class Controller(object):
             if targets is None:
                 raise RuntimeError('HCC_AMDGPU_TARGET is not set')
             log('HCC_AMDGPU_TARGET = {}'.format(targets))
+            video_group = os.environ.get('CUPY_RELEASE_VIDEO_GROUP', 'video')
             docker_run = [
                 'docker', 'run',
                 '--device=/dev/kfd', '--device=/dev/dri',
-                '--group-add', 'video',
                 '--env', 'HCC_AMDGPU_TARGET={}'.format(targets),
             ]
+            if video_group != '':
+                docker_run += ['--group-add', video_group]
         else:
             assert False
         command = docker_run + [

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -2,6 +2,7 @@ ARG base_image
 FROM ${base_image}
 
 USER root
+RUN [ ! -d /opt/rocm ] || ( curl -qL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - )
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y update && \
     apt-get -y install gcc g++ make patch git && \


### PR DESCRIPTION
* `video` group name is different depending on platform.
* ROCm PGP key has expired so need to load the latest key before using apt.