### PR TITLE
[v9] Fix ROCm CI for CuPy v9

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -24,7 +24,7 @@ configs {
     time_limit {
       seconds: 7200
     }
-    command: "sh .pfnci/wheel-linux/main.sh 3.8.0 rocm-4.2 master"
+    command: "sh .pfnci/wheel-linux/main.sh 3.8.0 rocm-4.2 v9"
     environment_variables { key: "CUPY_RELEASE_SKIP_VERIFY" value: "1" }
   }
 }


### PR DESCRIPTION
Follow-up: #158
I forgot to change the branch name in CI config...