### PR TITLE
Fix for ROCm 4.3

### DIFF
--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -61,6 +61,7 @@ ENV HOME /tmp
 
 # Hotfix for ROCm 4.3: shared libraries are not added to /etc/ld.so.conf.d
 ENV LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}"
+ENV LLVM_PATH="/opt/rocm/llvm"
 
 COPY agent.py /
 ENTRYPOINT ["/agent.py"]

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -59,5 +59,8 @@ RUN [ -z "${system_packages}" ] || ( \
 # Use /tmp as a temporary home to install package.
 ENV HOME /tmp
 
+# Hotfix for ROCm 4.3: shared libraries are not added to /etc/ld.so.conf.d
+ENV LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}"
+
 COPY agent.py /
 ENTRYPOINT ["/agent.py"]


### PR DESCRIPTION
ROCm 4.3 docker images does not have shared libraries on search path.

I'm testing locally now.