### PR TITLE
Fix invalid call to get_dist_info

### DIFF
--- a/.pfnci/wheel-linux/main.sh
+++ b/.pfnci/wheel-linux/main.sh
@@ -9,9 +9,6 @@ JOB_GROUP=${4:-}
 
 git clone --recursive --branch "${BRANCH}" --depth 1 https://github.com/cupy/cupy.git cupy
 
-# Display wheel information
-./get_dist_info.py --target wheel-linux --source ./cupy --cuda "${CUDA}" --python "${PYTHON}"
-
 ./build.sh "${CUDA}" "${PYTHON}"
 
 if [ -z "${JOB_GROUP}" ]; then


### PR DESCRIPTION
This fails when building an sdist (I did something unnecessary in #172... :bow:)