### PR TITLE
Use Python 3.9.0

### DIFF
--- a/dist_config.py
+++ b/dist_config.py
@@ -337,7 +337,7 @@ WHEEL_PYTHON_VERSIONS = {
         'abi_tag': 'cp38',
     },
     '3.9': {
-        'pyenv': '3.9.6',
+        'pyenv': '3.9.0',
         'python_tag': 'cp39',
         'abi_tag': 'cp39',
     },


### PR DESCRIPTION
It seems that sometimes `pyenv install 3.9.6` hangs for some reason.
Specifically, compileall in `make install` does not complete.

```
  |   |-{containerd-shim},1826922
  |   |-setup_python.sh,1826991 -uex /setup_python.sh 3.6.14 3.7.11 3.8.11 3.9.6 0.29.22
  |   |   `-bash,1827066 /opt/pyenv/plugins/python-build/bin/pyenv-install 3.9.6
  |   |       `-bash,1827255 /opt/pyenv/plugins/python-build/bin/python-build 3.9.6 /opt/pyenv/versions/3.9.6
  |   |           `-make,2210243 install
  |   |               `-python,2267221 -E -Wi -OO /opt/pyenv/versions/3.9.6/lib/python3.9/compileall.py -j0 -d ...
  |   |                   |-python,2268073 -E -Wi -OO /opt/pyenv/versions/3.9.6/lib/python3.9/compileall.py -j0 -d ...
  |   |                   |-{python},2268079
  |   |                   |-python,2268091 -E -Wi -OO /opt/pyenv/versions/3.9.6/lib/python3.9/compileall.py -j0 -d ...
						  ...
```

The reason is unknown but this was not happening with Python 3.9.0, so let's revert it for now.

Follow-up #172