### PR TITLE
Support building wheels for `aarch64`

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -14,6 +14,21 @@ configs {
   }
 }
 configs {
+  key: "cupy-release-tools.linux.jetson"
+  value {
+    requirement {
+      cpu: 8
+      memory: 36
+      disk: 30
+    }
+    time_limit {
+      seconds: 10800
+    }
+    command: "sh .pfnci/wheel-linux/main.sh 3.8 10.2-jetson master"
+    environment_variables { key: "CUPY_RELEASE_SKIP_VERIFY" value: "1" }
+  }
+}
+configs {
   key: "cupy-release-tools.linux.rocm"
   value {
     requirement {

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Linux
 ~~~~~
 
 * For ``sdist`` and CUDA (x86_64) wheel build, run the tool on Linux (x86_64). ``nvidia-docker`` and NVIDIA GPU are required for Verify step.
-* For CUDA (JetPack (aarch64)) wheel build, run the tool on Tegra device. ``nvidia-docker`` is required for Build and Verify step.
+* For CUDA (JetPack (aarch64)) wheel build, run the tool on Linux (x86_64 with QEMU (aarch64) or Tegra). ``nvidia-docker`` is required for Build and Verify step.
 * For ROCm wheel build, run the tool on Linux (x86_64). AMD GPU is required for Verify step.
 
 Notes:

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Linux
 ~~~~~
 
 * For ``sdist`` and CUDA (x86_64) wheel build, run the tool on Linux (x86_64). ``nvidia-docker`` and NVIDIA GPU are required for Verify step.
-* For CUDA (JetPack (aarch64)) wheel build, run the tool on Linux (x86_64 with QEMU (aarch64) or Tegra). ``nvidia-docker`` is required for Build and Verify step.
+* For CUDA (JetPack (aarch64)) wheel build, run the tool on Linux (x86_64 with QEMU (aarch64) or Tegra). ``nvidia-docker`` is required for Verify step.
 * For ROCm wheel build, run the tool on Linux (x86_64). AMD GPU is required for Verify step.
 
 Notes:

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@ cupy-release-tools
 ==================
 
 Tools to automate the CuPy release process.
+This tool is used to create both source distribution (``sdist``) and wheels.
 
 The release process consists of 3 steps:
 
@@ -12,23 +13,33 @@ The release process consists of 3 steps:
 Requirements
 ------------
 
-To build ``sdist`` and wheels for Linux, you will need:
+Linux
+~~~~~
 
-* Linux with Docker support
-* Docker
-* For CUDA build:
-    * ``nvidia-docker``
-    * ``tar`` with ``xz`` support
+* For ``sdist`` and CUDA (x86_64) wheel build, run the tool on Linux (x86_64). ``nvidia-docker`` and NVIDIA GPU are required for Verify step.
+* For CUDA (JetPack (aarch64)) wheel build, run the tool on Tegra device. ``nvidia-docker`` is required for Build and Verify step.
+* For ROCm wheel build, run the tool on Linux (x86_64). AMD GPU is required for Verify step.
 
-To build wheels for Windows, you will need:
+Notes:
 
-* Windows
-* Visual C++
+* To ensure the reproducibility of builds, the build environment is isolated by Docker.
+
+Windows
+~~~~~~~
+
+* Windows 8+ (x86_64)
+* Python, CUDA and Visual C++ are required. Versions depend on the target of the wheel.
+
+Notes:
+
+* Be aware that Windows tools in this repository is expected to be run on isolated virtual machine.
+  Especially note that the tool directly installs the dependency libraries to ``%CUDA_PATH%``.
+* ``sdist`` build on Windows is not supported.
 
 Quick Guide
 -----------
 
-You can use the following shell scripts that wrap the process on Linux.
+For Linux builds, you can use the ``build.sh`` shell script that wraps the Build and Verify steps.
 
 ::
 
@@ -46,13 +57,7 @@ For Windows, or if you need some more detailed configuration, see the sections b
 Build
 -----
 
-This tool can be used to create both source distribution (``sdist``) and wheels.
-To ensure the reproducibility of builds, the environment is isolated by Docker on Linux.
-
-Wheel Matrix
-~~~~~~~~~~~~
-
-This tool builds wheels for Linux & Windows (x86_64) for the matrix of all supported CUDA X Python variants, defined in ``dist_config.py``.
+This tool can build wheels for Linux & Windows for supported CUDA/ROCm x Python variants defined in ``dist_config.py``.
 
 Building Distributions
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -74,22 +79,23 @@ This example builds wheel of CuPy with CUDA 10.0 for Python 3.8.
   ./dist.py --action build --target wheel-linux --python 3.8 --cuda 10.0 --source path/to/cupy_repo
 
 Use ``--target wheel-win`` for Windows build.
+Use ``--cuda 10.2-jetson`` for JetPack (Tegra / CUDA 10.2 aarch64) build.
 Use ``--cuda rocm-4.3`` for ROCm (AMD GPU) build.
 
-Working Directory
-~~~~~~~~~~~~~~~~~
+The resulting asset (sdist/wheel) will be generated to the current directory.
+
+Working Directory (Linux)
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is safe to run multiple ``dist.py`` at a time.
 Each time you run the tool, a dedicated temporary directory (``/tmp/cupy-dist-XXXXX``) is created.
 The temporary directory is shared with the builder docker container as a volume.
 The working directory will be removed after the build.
 
-The resulting asset (sdist/wheel) will be copied back to the current directory.
-
 Verify
 ------
 
-The tool can be used to confirm that the built distribution will work with multiple environments.
+The tool can be used to confirm that the built distribution can work on multiple environments.
 
 Verifying Distributions
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/build.sh
+++ b/build.sh
@@ -16,11 +16,15 @@ case ${CUDA} in
 esac
 
 # Set VERIFY_ARGS
-VERIFY_ARGS="--test release-tests/common --test release-tests/nccl"
+VERIFY_ARGS="--test release-tests/common"
 case ${CUDA} in
   sdist )
     # CUDA (sdist)
-    VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/cudnn  --test release-tests/pkg_sdist"
+    VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/cudnn --test release-tests/nccl --test release-tests/pkg_sdist"
+    ;;
+  10.2-jetson )
+    # CUDA Jetson (wheel)
+    VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/cudnn"
     ;;
   rocm-* )
     # ROCm (wheel)
@@ -28,7 +32,7 @@ case ${CUDA} in
     ;;
   * )
     # CUDA (wheel)
-    VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/cudnn  --test release-tests/pkg_wheel"
+    VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/cudnn --test release-tests/nccl --test release-tests/pkg_wheel"
     ;;
 esac
 

--- a/builder/Dockerfile.jetson
+++ b/builder/Dockerfile.jetson
@@ -1,0 +1,49 @@
+ARG base_image
+FROM ${base_image}
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
+    apt-get -y install gcc g++ make patch git && \
+    apt-get -y install libbz2-dev liblzma-dev libssl-dev libreadline-dev libffi-dev && \
+    apt-get -y install python && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Install pyenv requirements.
+# https://github.com/pyenv/pyenv/wiki/Common-build-problems#requirements
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
+    apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev \
+    libncursesw5-dev xz-utils tk-dev && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Install pyenv.
+RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
+ENV PYENV_ROOT=/opt/pyenv
+ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+
+# Install Python.
+ARG python_versions
+ARG cython_version
+COPY setup_python.sh /
+RUN /setup_python.sh "${python_versions}" "${cython_version}"
+
+# Install additional libraries for CUDA.
+COPY cuda_lib/ /cuda_lib
+COPY setup_cuda_opt_lib.py /
+RUN /setup_cuda_opt_lib.py --src /cuda_lib --dst /usr/local/cuda
+
+# Install additional dependicies.
+ARG system_packages
+RUN [ -z "${system_packages}" ] || ( \
+        export DEBIAN_FRONTEND=noninteractive && \
+        apt-get -y update && \
+        apt-get -y install ${system_packages} && \
+        rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+    )
+
+# Add build agent.
+COPY build-wrapper-jetson /build-wrapper
+COPY agent.py /
+
+ENTRYPOINT ["/agent.py"]

--- a/builder/base/cuda-10.2-jetson/.gitignore
+++ b/builder/base/cuda-10.2-jetson/.gitignore
@@ -1,0 +1,4 @@
+image.zip
+sd-blob-b01.img
+_jetson-rootfs.tar
+_jetson-rootfs/

--- a/builder/base/cuda-10.2-jetson/Dockerfile
+++ b/builder/base/cuda-10.2-jetson/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+ADD _jetson-rootfs.tar /
+RUN /bin/sed -i 's|<SOC>|t210|g' /etc/apt/sources.list.d/nvidia-l4t-apt-source.list
+CMD /bin/bash

--- a/builder/base/cuda-10.2-jetson/build.sh
+++ b/builder/base/cuda-10.2-jetson/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script requires sudo privilage, and assumes parted (partprobe) installed.
+# Note: this process cannot be containerized as `partprobe` relies on udev.
+
+set -uex
+
+sudo echo "Checking sudo privilage"
+
+if [ ! -f sd-blob-b01.img ]; then
+    if [ ! -f image.zip ]; then
+        wget -q -O image.zip "https://developer.nvidia.com/embedded/l4t/r32_release_v6.1/jeston_nano/jetson-nano-jp46-sd-card-image.zip"
+    fi
+    unzip image.zip
+fi
+
+LOOP_DEV=$(sudo losetup --show -f sd-blob-b01.img)
+trap "sudo umount ${LOOP_DEV}p1; sudo losetup -d ${LOOP_DEV}" EXIT
+sudo partprobe "${LOOP_DEV}"
+mkdir -p _jetson-rootfs
+sudo mount -o ro "${LOOP_DEV}p1" _jetson-rootfs
+sudo tar cf _jetson-rootfs.tar -C _jetson-rootfs .
+
+sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+sudo docker build -t asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson .
+echo "Done. Maintainers can push the Docker image by:"
+echo "$ docker push asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson"

--- a/builder/build-wrapper-jetson
+++ b/builder/build-wrapper-jetson
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export CUPY_NVCC_GENERATE_CODE="arch=compute_72,code=sm_72;arch=compute_62,code=sm_62;arch=compute_53,code=sm_53"
+
+"$@"

--- a/dist.py
+++ b/dist.py
@@ -81,6 +81,16 @@ def prepare_cuda_opt_library(library, cuda_version, prefix):
     return metadata
 
 
+def build_needs_docker_runtime():
+    if os.uname().machine == 'aarch64':
+        # It seems that L4T docker image does not contain cuBLAS and cuDNN,
+        # that are needed to build CuPy.
+        # They are mounted from host only when launching a container via
+        # nvidia-docker.
+        return True
+    return False
+
+
 class Controller(object):
 
     def parse_args(self):
@@ -386,7 +396,8 @@ class Controller(object):
             # Build.
             log('Starting build')
             self._run_container(
-                image_tag, kind, workdir, agent_args, require_runtime=False)
+                image_tag, kind, workdir, agent_args,
+                require_runtime=build_needs_docker_runtime())
             log('Finished build')
 
             # Copy assets.

--- a/dist.py
+++ b/dist.py
@@ -25,7 +25,7 @@ from dist_config import (
 )  # NOQA
 
 from dist_utils import (
-    wheel_platform_tag,
+    wheel_linux_platform_tag,
     sdist_name,
     wheel_name,
     get_version_from_source_tree,
@@ -286,10 +286,10 @@ class Controller(object):
             # Rename wheels to manylinux.
             asset_name = wheel_name(
                 package_name, version, python_version,
-                wheel_platform_tag(arch, False))
+                wheel_linux_platform_tag(arch, False))
             asset_dest_name = wheel_name(
                 package_name, version, python_version,
-                wheel_platform_tag(arch, True))
+                wheel_linux_platform_tag(arch, True))
         elif target == 'sdist':
             assert cuda_version is None
             log('Starting sdist build from {} (version {})'.format(

--- a/dist.py
+++ b/dist.py
@@ -156,7 +156,8 @@ class Controller(object):
                     args.dist, args.test)
 
     def _create_builder_linux(
-            self, image_tag, base_image, system_packages, docker_ctx):
+            self, image_tag, base_image, builder_dockerfile, system_packages,
+            docker_ctx):
         """Create a docker image to build distributions."""
 
         python_versions = ' '.join(
@@ -164,6 +165,7 @@ class Controller(object):
         log('Building Docker image: {}'.format(image_tag))
         run_command(
             'docker', 'build',
+            '--file', f'{docker_ctx}/{builder_dockerfile}',
             '--tag', image_tag,
             '--build-arg', 'base_image={}'.format(base_image),
             '--build-arg', 'python_versions={}'.format(python_versions),
@@ -264,6 +266,8 @@ class Controller(object):
             platform_version = WHEEL_LINUX_CONFIGS[cuda_version].get(
                 'platform_version', cuda_version)
             base_image = WHEEL_LINUX_CONFIGS[cuda_version]['image']
+            builder_dockerfile = WHEEL_LINUX_CONFIGS[cuda_version].get(
+                'builder_dockerfile', 'Dockerfile')
             package_name = WHEEL_LINUX_CONFIGS[cuda_version]['name']
             system_packages = \
                 WHEEL_LINUX_CONFIGS[cuda_version]['system_packages']
@@ -293,6 +297,7 @@ class Controller(object):
             kind = 'cuda'
             preloads = []
             base_image = SDIST_CONFIG['image']
+            builder_dockerfile = 'Dockerfile'
             package_name = 'cupy'
             system_packages = ''
             long_description = SDIST_LONG_DESCRIPTION
@@ -375,7 +380,8 @@ class Controller(object):
 
             # Creates a Docker image to build distribution.
             self._create_builder_linux(
-                image_tag, base_image, system_packages, docker_ctx)
+                image_tag, base_image, builder_dockerfile, system_packages,
+                docker_ctx)
 
             # Build.
             log('Starting build')

--- a/dist.py
+++ b/dist.py
@@ -25,6 +25,7 @@ from dist_config import (
 )  # NOQA
 
 from dist_utils import (
+    wheel_platform_tag,
     sdist_name,
     wheel_name,
     get_version_from_source_tree,
@@ -179,7 +180,8 @@ class Controller(object):
         if 'rhel' in base_image or 'centos' in base_image:
             log('Using RHEL Dockerfile template')
             template = 'rhel'
-        elif 'ubuntu' in base_image or 'rocm' in base_image:
+        elif ('ubuntu' in base_image or 'rocm' in base_image or
+                'l4t-base' in base_image):
             log('Using Debian Dockerfile template')
             template = 'debian'
         else:
@@ -275,11 +277,13 @@ class Controller(object):
             long_description = long_description_tmpl.format(
                 version=platform_version)
 
-            # Rename wheels to manylinux1.
+            # Rename wheels to manylinux.
             asset_name = wheel_name(
-                package_name, version, python_version, 'linux_x86_64')
+                package_name, version, python_version,
+                wheel_platform_tag(False))
             asset_dest_name = wheel_name(
-                package_name, version, python_version, 'manylinux1_x86_64')
+                package_name, version, python_version,
+                wheel_platform_tag(True))
         elif target == 'sdist':
             assert cuda_version is None
             log('Starting sdist build from {} (version {})'.format(

--- a/dist.py
+++ b/dist.py
@@ -272,6 +272,7 @@ class Controller(object):
             action = 'bdist_wheel'
             image_tag = 'cupy-builder-{}'.format(cuda_version)
             kind = WHEEL_LINUX_CONFIGS[cuda_version]['kind']
+            arch = WHEEL_LINUX_CONFIGS[cuda_version].get('arch', 'x86_64')
             preloads = WHEEL_LINUX_CONFIGS[cuda_version]['preloads']
             platform_version = WHEEL_LINUX_CONFIGS[cuda_version].get(
                 'platform_version', cuda_version)
@@ -294,10 +295,10 @@ class Controller(object):
             # Rename wheels to manylinux.
             asset_name = wheel_name(
                 package_name, version, python_version,
-                wheel_platform_tag(False))
+                wheel_platform_tag(arch, False))
             asset_dest_name = wheel_name(
                 package_name, version, python_version,
-                wheel_platform_tag(True))
+                wheel_platform_tag(arch, True))
         elif target == 'sdist':
             assert cuda_version is None
             log('Starting sdist build from {} (version {})'.format(

--- a/dist.py
+++ b/dist.py
@@ -81,16 +81,6 @@ def prepare_cuda_opt_library(library, cuda_version, prefix):
     return metadata
 
 
-def build_needs_docker_runtime():
-    if os.uname().machine == 'aarch64':
-        # It seems that L4T docker image does not contain cuBLAS and cuDNN,
-        # that are needed to build CuPy.
-        # They are mounted from host only when launching a container via
-        # nvidia-docker.
-        return True
-    return False
-
-
 class Controller(object):
 
     def parse_args(self):
@@ -398,7 +388,7 @@ class Controller(object):
             log('Starting build')
             self._run_container(
                 image_tag, kind, workdir, agent_args,
-                require_runtime=build_needs_docker_runtime())
+                require_runtime=False)
             log('Finished build')
 
             # Copy assets.

--- a/dist_config.py
+++ b/dist_config.py
@@ -53,7 +53,7 @@ WHEEL_LINUX_CONFIGS = {
         'platform_version': '10.2',
         # Note: this image is not publicly accessible.
         # Use `buidler/base/cuda-10.2-jetson` to build by your own.
-        'image': 'asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson',
+        'image': 'asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson',  # NOQA
         'libs': [
         ],
         'includes': [

--- a/dist_config.py
+++ b/dist_config.py
@@ -51,7 +51,9 @@ WHEEL_LINUX_CONFIGS = {
         'kind': 'cuda',
         'arch': 'aarch64',
         'platform_version': '10.2',
-        'image': 'nvcr.io/nvidia/l4t-base:r32.5.0',
+        # Note: this image is not publicly accessible.
+        # Use `buidler/base/cuda-10.2-jetson` to build by your own.
+        'image': 'asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson',
         'libs': [
         ],
         'includes': [

--- a/dist_config.py
+++ b/dist_config.py
@@ -20,8 +20,9 @@ SDIST_CONFIG = {
 # Keys of the build settings are as follows:
 # - `name`: a package name
 # - `kind`: type of the package (`cuda` or `rocm`)
+# - `arch`: platform for the package (optional, default: `x86_64`)
 # - `platform_version`: alternate name of the `kind` platform version used
-#                       for long description
+#                       for long description (optional, defualt: dict key)
 # - `image`: a name of the base docker image name used for build
 # - `libs`: a list of shared libraries to be bundled in wheel
 # - `includes`: a list of header files to be bundled in wheel
@@ -48,6 +49,8 @@ WHEEL_LINUX_CONFIGS = {
     '10.2-jetson': {
         'name': 'cupy-cuda102',
         'kind': 'cuda',
+        'arch': 'aarch64',
+        'platform_version': '10.2',
         'image': 'nvcr.io/nvidia/l4t-base:r32.5.0',
         'libs': [
         ],

--- a/dist_config.py
+++ b/dist_config.py
@@ -45,6 +45,20 @@ WHEEL_LINUX_CONFIGS = {
         'verify_systems': ['ubuntu16.04'],
         'system_packages': '',
     },
+    '10.2-jetson': {
+        'name': 'cupy-cuda102',
+        'kind': 'cuda',
+        'image': 'nvcr.io/nvidia/l4t-base:r32.5.0',
+        'libs': [
+        ],
+        'includes': [
+        ],
+        'builder_dockerfile': 'Dockerfile.jetson',
+        'preloads': [],  # no extra libraries in Jetson
+        'verify_image': 'nvcr.io/nvidia/l4t-base:r32.5.0',
+        'verify_systems': ['default'],
+        'system_packages': '',
+    },
     '11.0': {
         'name': 'cupy-cuda110',
         'kind': 'cuda',

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -8,6 +8,20 @@ import os
 from dist_config import WHEEL_PYTHON_VERSIONS
 
 
+def wheel_platform_tag(manylinux):
+    cpu = os.uname().machine
+    if manylinux:
+        if cpu == 'aarch64':
+            tag = 'manylinux2014'
+        elif cpu == 'x86_64':
+            tag = 'manylinux1'
+        else:
+            assert False
+    else:
+        tag = 'linux'
+    return f'{tag}_{cpu}'
+
+
 def sdist_name(package_name, version):
     return '{package_name}-{version}.tar.gz'.format(
         package_name=package_name,

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -8,7 +8,7 @@ import os
 from dist_config import WHEEL_PYTHON_VERSIONS
 
 
-def wheel_platform_tag(cpu: str, manylinux: bool) -> str:
+def wheel_linux_platform_tag(cpu: str, manylinux: bool) -> str:
     assert cpu in ('aarch64', 'x86_64')
     if manylinux:
         if cpu == 'aarch64':

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -8,8 +8,8 @@ import os
 from dist_config import WHEEL_PYTHON_VERSIONS
 
 
-def wheel_platform_tag(manylinux):
-    cpu = os.uname().machine
+def wheel_platform_tag(cpu: str, manylinux: bool) -> str:
+    assert cpu in ('aarch64', 'x86_64')
     if manylinux:
         if cpu == 'aarch64':
             tag = 'manylinux2014'

--- a/get_dist_info.py
+++ b/get_dist_info.py
@@ -47,7 +47,8 @@ class DistInfoPrinter(object):
             pkg_name = WHEEL_LINUX_CONFIGS[args.cuda]['name']
             arch = WHEEL_LINUX_CONFIGS[args.cuda].get('arch', 'x86_64')
             filename = wheel_name(
-                pkg_name, version, args.python, wheel_linux_platform_tag(arch, True))
+                pkg_name, version, args.python,
+                wheel_linux_platform_tag(arch, True))
         elif args.target == 'wheel-win':
             pkg_name = WHEEL_WINDOWS_CONFIGS[args.cuda]['name']
             filename = wheel_name(pkg_name, version, args.python, 'win_amd64')

--- a/get_dist_info.py
+++ b/get_dist_info.py
@@ -45,8 +45,9 @@ class DistInfoPrinter(object):
         version = get_version_from_source_tree(args.source)
         if args.target == 'wheel-linux':
             pkg_name = WHEEL_LINUX_CONFIGS[args.cuda]['name']
+            arch = WHEEL_LINUX_CONFIGS[args.cuda].get('arch', 'x86_64')
             filename = wheel_name(
-                pkg_name, version, args.python, wheel_platform_tag(True))
+                pkg_name, version, args.python, wheel_platform_tag(arch, True))
         elif args.target == 'wheel-win':
             pkg_name = WHEEL_WINDOWS_CONFIGS[args.cuda]['name']
             filename = wheel_name(pkg_name, version, args.python, 'win_amd64')

--- a/get_dist_info.py
+++ b/get_dist_info.py
@@ -10,7 +10,7 @@ from dist_config import (
 )  # NOQA
 
 from dist_utils import (
-    wheel_platform_tag,
+    wheel_linux_platform_tag,
     sdist_name,
     wheel_name,
     get_version_from_source_tree,
@@ -47,7 +47,7 @@ class DistInfoPrinter(object):
             pkg_name = WHEEL_LINUX_CONFIGS[args.cuda]['name']
             arch = WHEEL_LINUX_CONFIGS[args.cuda].get('arch', 'x86_64')
             filename = wheel_name(
-                pkg_name, version, args.python, wheel_platform_tag(arch, True))
+                pkg_name, version, args.python, wheel_linux_platform_tag(arch, True))
         elif args.target == 'wheel-win':
             pkg_name = WHEEL_WINDOWS_CONFIGS[args.cuda]['name']
             filename = wheel_name(pkg_name, version, args.python, 'win_amd64')

--- a/get_dist_info.py
+++ b/get_dist_info.py
@@ -10,6 +10,7 @@ from dist_config import (
 )  # NOQA
 
 from dist_utils import (
+    wheel_platform_tag,
     sdist_name,
     wheel_name,
     get_version_from_source_tree,
@@ -45,7 +46,7 @@ class DistInfoPrinter(object):
         if args.target == 'wheel-linux':
             pkg_name = WHEEL_LINUX_CONFIGS[args.cuda]['name']
             filename = wheel_name(
-                pkg_name, version, args.python, 'manylinux1_x86_64')
+                pkg_name, version, args.python, wheel_platform_tag(True))
         elif args.target == 'wheel-win':
             pkg_name = WHEEL_WINDOWS_CONFIGS[args.cuda]['name']
             filename = wheel_name(pkg_name, version, args.python, 'win_amd64')


### PR DESCRIPTION
This PR adds `manylinux2014_aarch64` support, targetting JetPack SDK (CUDA 10.2).