### PR TITLE
Fix for Jetson CI

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -22,7 +22,7 @@ configs {
       disk: 30
     }
     time_limit {
-      seconds: 10800
+      seconds: 18000
     }
     command: "sh .pfnci/wheel-linux/main.sh 3.8 10.2-jetson master"
     environment_variables { key: "CUPY_RELEASE_SKIP_VERIFY" value: "1" }

--- a/.pfnci/wheel-linux/main.sh
+++ b/.pfnci/wheel-linux/main.sh
@@ -7,6 +7,8 @@ CUDA=$2
 BRANCH=$3
 JOB_GROUP=${4:-}
 
+gcloud auth configure-docker || echo "Failed to configure access to GCR"
+
 git clone --recursive --branch "${BRANCH}" --depth 1 https://github.com/cupy/cupy.git cupy
 
 ./build.sh "${CUDA}" "${PYTHON}"


### PR DESCRIPTION
This allows CI to use Docker images pushed to GCR.

Jetson build CI should work with this PR.
(currently failing: https://ci.preferred.jp/cupy-release-tools.linux.jetson/83041/)

Test running: https://ci.preferred.jp/cupy-release-tools.linux.jetson/83500/