### PR TITLE
Remove code path for CentOS 6

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,7 +1,6 @@
 ARG base_image
 FROM ${base_image}
 
-RUN sed -ie 's|#baseurl=http://mirror.centos.org/centos/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/centos/|g' /etc/yum.repos.d/CentOS-Base.repo
 RUN yum -y install gcc gcc-c++ make patch git curl && \
     yum -y install bzip2-devel openssl-devel readline-devel libffi-devel && \
     yum -y install epel-release && \

--- a/builder/setup_devtoolset.sh
+++ b/builder/setup_devtoolset.sh
@@ -2,15 +2,7 @@
 
 yum install -y centos-release-scl
 
-if [ $(rpm --eval '%{rhel}') == 6 ]; then
-    # CentOS 6
-    perl -pi -e 's|^#baseurl=http://mirror.centos.org/centos/6/sclo/\$basearch/rh/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/6.8/sclo/\$basearch/rh/|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    perl -pi -e 's|^# baseurl=http://mirror.centos.org/centos/6/sclo/\$basearch/sclo/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/6.8/sclo/\$basearch/sclo/|' /etc/yum.repos.d/CentOS-SCLo-scl.repo
-    perl -pi -e 's|^mirrorlist=|#mirrorlist=|' /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-    yum install -y devtoolset-6-gcc-c++
-else
-    # CentOS 7
-    yum install -y devtoolset-7-gcc-c++
-fi
+# CentOS 7
+yum install -y devtoolset-7-gcc-c++
 
 yum clean all

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -2,7 +2,6 @@ ARG base_image
 FROM ${base_image}
 
 USER root
-RUN sed -ie 's|#baseurl=http://mirror.centos.org/centos/|baseurl=http://ftp.iij.ad.jp/pub/linux/centos-vault/centos/|g' /etc/yum.repos.d/CentOS-Base.repo
 RUN yum -y update && \
     yum -y install gcc gcc-c++ make patch git && \
     yum -y install bzip2-devel openssl-devel readline-devel libffi-devel && \


### PR DESCRIPTION
(code fix, not urgent)

v10 no longer uses CentOS 6 for wheel build. (https://github.com/cupy/cupy-release-tools/pull/193)

Closes #72