### PR TITLE
Build Linux wheels in one FlexCI instance for each CUDA

### DIFF
--- a/.pfnci/build_submit.sh
+++ b/.pfnci/build_submit.sh
@@ -34,15 +34,11 @@ submit_job cupy-wheel-linux ".pfnci/wheel-linux/main.sh sdist 3.7 ${BRANCH} ${JO
 
 # wheels (Linux)
 for CUDA in 10.2 11.0 11.1 11.2 11.3 11.4 11.5; do
-  for PYTHON in 3.7 3.8 3.9 3.10; do
-    submit_job cupy-wheel-linux ".pfnci/wheel-linux/main.sh ${CUDA} ${PYTHON} ${BRANCH} ${JOB_GROUP}"
-  done
+  submit_job cupy-wheel-linux ".pfnci/wheel-linux/main.sh ${CUDA} 3.7,3.8,3.9,3.10 ${BRANCH} ${JOB_GROUP}"
 done
 
 # Wheel (Linux / Jetson)
-for PYTHON in 3.7 3.8 3.9 3.10; do
-  submit_job cupy-release-tools.linux.jetson ".pfnci/wheel-linux/main.sh 10.2-jetson ${PYTHON} ${BRANCH} ${JOB_GROUP}"
-done
+submit_job cupy-release-tools.linux.jetson ".pfnci/wheel-linux/main.sh 10.2-jetson 3.7,3.8,3.9,3.10 ${BRANCH} ${JOB_GROUP}"
 
 # wheels (Windows)
 for CUDA in 10.2 11.0 11.1 11.2 11.3 11.4 11.5; do

--- a/.pfnci/wheel-linux/main.sh
+++ b/.pfnci/wheel-linux/main.sh
@@ -15,7 +15,9 @@ fi
 
 git clone --recursive --branch "${BRANCH}" --depth 1 https://github.com/cupy/cupy.git cupy
 
-./build.sh "${CUDA}" "${PYTHON}"
+for PY in $(echo ${PYTHON} | tr ',' ' '); do
+    ./build.sh "${CUDA}" "${PY}"
+done
 
 if [ -z "${JOB_GROUP}" ]; then
     echo "Upload skipped as JOB_GROUP is not specified"


### PR DESCRIPTION
(code fix, not urgent)

Currently, each wheel build FlexCI job (1 CUDA & 1 Python) takes approx 27 minutes. Time breakdown is as follows:

* 13 minutes for Docker image build (builder/verifier)
* 14 minutes for CuPy build & test

However, Docker image (builder/verifier) can be reused for all Python versions within the same CUDA version.
Thus it is better to assign 1 CUDA & 4 Python to each FlexCI job to reduce build time.

Depends on #208