### PR TITLE
Separately build for Jetson

### DIFF
--- a/.pfnci/build_submit.sh
+++ b/.pfnci/build_submit.sh
@@ -38,7 +38,9 @@ for CUDA in 10.2 11.0 11.1 11.2 11.3 11.4 11.5; do
 done
 
 # Wheel (Linux / Jetson)
-submit_job cupy-release-tools.linux.jetson ".pfnci/wheel-linux/main.sh 10.2-jetson 3.7,3.8,3.9,3.10 ${BRANCH} ${JOB_GROUP}"
+for PYTHON in 3.7 3.8 3.9 3.10; do
+  submit_job cupy-release-tools.linux.jetson ".pfnci/wheel-linux/main.sh 10.2-jetson ${PYTHON} ${BRANCH} ${JOB_GROUP}"
+done
 
 # wheels (Windows)
 for CUDA in 10.2 11.0 11.1 11.2 11.3 11.4 11.5; do


### PR DESCRIPTION
Avoid timeout by separately build for each Python.