### PR TITLE
Update setuptools to avoid distutils warnings

### DIFF
--- a/.pfnci/wheel-windows/build.ps1
+++ b/.pfnci/wheel-windows/build.ps1
@@ -63,6 +63,8 @@ echo ">> Using Branch: $branch"
 RunOrDie git clone --recursive --branch $branch --depth 1 https://github.com/cupy/cupy.git cupy
 
 # Install dependencies
+echo ">> Updating packaging utilities..."
+RunOrDie python -m pip install -U setuptools pip
 echo ">> Installing dependences for wheel build..."
 RunOrDie python -m pip install -U wheel Cython pytest
 echo ">> Packages installed:"


### PR DESCRIPTION
This fixes the following error (warning emitted by `numpy.distutils`) by overriding python's built-in distutils module with the one comes with setuptools 60.0+.
https://ci.preferred.jp/cupy-release-tools.win/90442/

```
setuptools   57.4.0

...

DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
```