### PR TITLE
Respect shebang to run CI

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -10,7 +10,7 @@ configs {
     time_limit {
       seconds: 10800
     }
-    command: "sh .pfnci/wheel-linux/main.sh 11.5 3.7"
+    command: ".pfnci/wheel-linux/main.sh 11.5 3.7"
   }
 }
 configs {
@@ -24,7 +24,7 @@ configs {
     time_limit {
       seconds: 18000
     }
-    command: "sh .pfnci/wheel-linux/main.sh 10.2-jetson 3.8"
+    command: ".pfnci/wheel-linux/main.sh 10.2-jetson 3.8"
     environment_variables { key: "CUPY_RELEASE_SKIP_VERIFY" value: "1" }
   }
 }
@@ -39,7 +39,7 @@ configs {
     time_limit {
       seconds: 10800
     }
-    command: "sh .pfnci/wheel-linux/main.sh rocm-4.3 3.8"
+    command: ".pfnci/wheel-linux/main.sh rocm-4.3 3.8"
     environment_variables { key: "CUPY_RELEASE_SKIP_VERIFY" value: "1" }
   }
 }

--- a/.pfnci/wheel-linux/main.sh
+++ b/.pfnci/wheel-linux/main.sh
@@ -16,7 +16,7 @@ fi
 # TODO: revert after confirming CUDA 11.6 driver work on GCP
 if [[ "${CUDA}" = "11.6" ]]; then
     export CUPY_RELEASE_SKIP_VERIFY=1
-elif [[ "${CUPY_RELEASE_SKIP_VERIFY:-}" != "" ]]; then
+elif [[ "${CUPY_RELEASE_SKIP_VERIFY:-}" = "" ]]; then
     export CUPY_RELEASE_SKIP_VERIFY=0
 fi
 


### PR DESCRIPTION
Following up #236. `/bin/sh` is dash on Ubuntu, and it doesn't have bash-specific builtin.

https://ci.preferred.jp/cupy-release-tools/96546/
```
+ [[ 11.5 = 11.6 ]]
.pfnci/wheel-linux/main.sh: 17: [[: not found
+ [[  !=  ]]
.pfnci/wheel-linux/main.sh: 19: [[: not found
```