### PR TITLE
Fix verifier for ROCm 4.3

### DIFF
--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -55,5 +55,8 @@ RUN [ -z "${system_packages}" ] || ( \
 # Use /tmp as a temporary home to install package.
 ENV HOME /tmp
 
+# For ROCm 4.3+ (shared libraries are not added to /etc/ld.so.conf.d)
+ENV LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}"
+
 COPY agent.py /
 ENTRYPOINT ["/agent.py"]


### PR DESCRIPTION
This reverts the env var `LD_LIBRARY_PATH` removed in #237. This is still needed for ROCm 4.3 or 5.0.