### PR TITLE
Improve build of CUDA 10.2 Jetson wheels

### DIFF
--- a/builder/base/cuda-10.2-jetson/.dockerignore
+++ b/builder/base/cuda-10.2-jetson/.dockerignore
@@ -1,0 +1,2 @@
+*
+!_jetson-rootfs.tar

--- a/builder/base/cuda-10.2-jetson/build.sh
+++ b/builder/base/cuda-10.2-jetson/build.sh
@@ -21,7 +21,8 @@ mkdir -p _jetson-rootfs
 sudo mount -o ro "${LOOP_DEV}p1" _jetson-rootfs
 sudo tar cf _jetson-rootfs.tar -C _jetson-rootfs .
 
-sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-sudo docker build -t asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson .
+[[ $(uname -m) = aarch64 ]] || docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+export DOCKER_BUILDKIT=1
+docker build -t cupy/cupy-release-tools:cuda-10.2-jetson --build-arg BUILDKIT_INLINE_CACHE=1 .
 echo "Done. Maintainers can push the Docker image by:"
-echo "$ docker push asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson"
+echo "$ docker push cupy/cupy-release-tools:cuda-10.2-jetson"

--- a/dist_config.py
+++ b/dist_config.py
@@ -51,9 +51,7 @@ WHEEL_LINUX_CONFIGS = {
         'kind': 'cuda',
         'arch': 'aarch64',
         'platform_version': '10.2',
-        # Note: this image is not publicly accessible.
-        # Use `buidler/base/cuda-10.2-jetson` to build by your own.
-        'image': 'asia.gcr.io/pfn-public-ci/cupy-release-tools:cuda-10.2-jetson',  # NOQA
+        'image': 'cupy/cupy-release-tools:cuda-10.2-jetson',  # NOQA
         'libs': [
         ],
         'includes': [


### PR DESCRIPTION
* Use public docker image so that everyone can reproduce the build.
* Improve build performance of CUDA 10.2 Jetson base image by excluding unnecessary files (`.dockerignore`)