### PR TITLE
Fix verifier for ubi8

### DIFF
--- a/verifier/Dockerfile.el8
+++ b/verifier/Dockerfile.el8
@@ -4,7 +4,7 @@ FROM ${base_image}
 USER root
 RUN yum -y update --nobest && \
     yum -y install gcc gcc-c++ make patch git && \
-    yum -y install bzip2-devel openssl-devel && \
+    yum -y install bzip2-devel openssl-devel libffi-devel && \
     yum clean all
 
 # Install pyenv.


### PR DESCRIPTION
In UBI8, `libffi-devel` is required to build `ctypes` Python module.