### PR TITLE
Add `cupy-cuda11x` wheel configuration

### DIFF
--- a/.pfnci/wheel-windows/_flexci.ps1
+++ b/.pfnci/wheel-windows/_flexci.ps1
@@ -48,6 +48,8 @@ function ActivateCUDA($version) {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V11_6
     } elseif ($version -eq "11.7") {
         $Env:CUDA_PATH = $Env:CUDA_PATH_V11_7
+    } elseif ($version -eq "11.x") {
+        $Env:CUDA_PATH = $Env:CUDA_PATH_V11_7
     } else {
         throw "Unsupported CUDA version: $version"
     }

--- a/dist_config.py
+++ b/dist_config.py
@@ -200,6 +200,51 @@ WHEEL_LINUX_CONFIGS = {
         'verify_systems': ['ubi8'],
         'system_packages': '',
     },
+    '11.x': {
+        # CUDA Enhanced Compatibility wheel (for CUDA 11.2~11.x)
+        'name': 'cupy-cuda11x',
+        'kind': 'cuda',
+        'platform_version': '11.2 ~ 11.x',
+        # Use the latest CUDA version for build.
+        'image': 'cupy/cupy-release-tools:cuda-runfile-11.7.0-centos7',
+        'libs': [],
+        'includes': [],
+        'preloads': ['cutensor', 'nccl', 'cudnn'],
+        'verify_image': 'nvidia/cuda:{system}',
+        'verify_systems': [
+            # Test on all supported CUDA version variants.
+            '11.2.2-runtime-ubuntu18.04',
+            '11.3.1-runtime-ubuntu18.04',
+            '11.4.3-runtime-ubuntu18.04',
+            '11.5.2-runtime-ubuntu18.04',
+            '11.6.2-runtime-ubuntu18.04',
+            '11.7.0-runtime-ubuntu18.04',
+        ],
+        'system_packages': '',
+    },
+    '11.x-aarch64': {
+        # CUDA Enhanced Compatibility wheel (for CUDA 11.2~11.x)
+        'name': 'cupy-cuda11x',
+        'kind': 'cuda',
+        'arch': 'aarch64',
+        'platform_version': '11.2 ~ 11.x',
+        # Use the latest image.
+        'image': 'cupy/cupy-release-tools:cuda-runfile-11.7.0-el8',
+        'libs': [],
+        'includes': [],
+        'preloads': [],
+        'verify_image': 'nvidia/cuda:{system}',
+        'verify_systems': [
+            # Test on all supported CUDA version variants.
+            '11.2.1-runtime-ubi8',
+            '11.3.0-runtime-ubi8',
+            '11.4.2-runtime-ubi8',
+            '11.5.1-runtime-ubi8',
+            '11.6.1-runtime-ubi8',
+            '11.7.0-runtime-ubi8',
+        ],
+        'system_packages': '',
+    },
     'rocm-4.2': {
         'name': 'cupy-rocm-4-2',
         'kind': 'rocm',

--- a/dist_config.py
+++ b/dist_config.py
@@ -380,6 +380,17 @@ WHEEL_WINDOWS_CONFIGS = {
         'cudart_lib': 'cudart64_110',  # binary compatible between CUDA 11.x
         'check_version': lambda x: 11070 <= x < 11080,
     },
+    '11.x': {
+        # CUDA Enhanced Compatibility wheel (for CUDA 11.2~11.x)
+        'name': 'cupy-cuda11x',
+        'kind': 'cuda',
+        'libs': [
+            'nvToolsExt64_1.dll',  # NVIDIA Tools Extension Library
+        ],
+        'preloads': ['cutensor', 'cudnn'],
+        'cudart_lib': 'cudart64_110',  # binary compatible between CUDA 11.x
+        'check_version': lambda x: 11070 <= x < 11080,
+    },
 }
 
 


### PR DESCRIPTION
This depends on ~https://github.com/cupy/cupy/pull/6800~ and ~#257~ (merged).

No backport needed.