### PR TITLE
Skip updating GPG key for Jetson as JetPack does not contain gnupg by default

### DIFF
--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -5,7 +5,7 @@ USER root
 RUN [ ! -d /opt/rocm ] || ( curl -qL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - )
 
 # Update CUDA GPG key
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub || echo "Skip updating GPG key"
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y update && \


### PR DESCRIPTION
This supports building verifier docker image for Jeston.