### PR TITLE
Always use a manylinux2014 tag for manylinux

### DIFF
--- a/check_release_assets.py
+++ b/check_release_assets.py
@@ -13,7 +13,7 @@ CP37 = 'cp37-cp37m'
 CP38 = 'cp38-cp38'
 CP39 = 'cp39-cp39'
 CP310 = 'cp310-cp310'
-LINUX = 'manylinux1_x86_64'
+LINUX = 'manylinux2014_x86_64'
 LINUX_AARCH64 = 'manylinux2014_aarch64'
 WINDOWS = 'win_amd64'
 

--- a/dist_utils.py
+++ b/dist_utils.py
@@ -11,12 +11,7 @@ from dist_config import WHEEL_PYTHON_VERSIONS
 def wheel_linux_platform_tag(cpu: str, manylinux: bool) -> str:
     assert cpu in ('aarch64', 'x86_64')
     if manylinux:
-        if cpu == 'aarch64':
-            tag = 'manylinux2014'
-        elif cpu == 'x86_64':
-            tag = 'manylinux1'
-        else:
-            assert False
+        tag = 'manylinux2014'
     else:
         tag = 'linux'
     return f'{tag}_{cpu}'


### PR DESCRIPTION
`x86_64` wheels are currently published as `manylinux1` wheels but they are built on CentOS 7 and require symbols only found in GLIBC 2.17+
Bump the manylinux tag to `manylinux2014` to reflect this requirement.