### PR TITLE
Use `SimpleScrapingLocator`

### DIFF
--- a/check_release_assets.py
+++ b/check_release_assets.py
@@ -77,7 +77,8 @@ wheel_projects = {
 def get_basenames(project, version):
     # List all wheels including unsupported ones by the current Python
     distlib.locators.is_compatible = lambda *args: True
-    locator = distlib.locators.SimpleScrapingLocator('https://pypi.org/simple/')
+    locator = distlib.locators.SimpleScrapingLocator(
+        'https://pypi.org/simple/')
     proj = locator.get_project(project)['urls']
     if version not in proj:
         return []

--- a/check_release_assets.py
+++ b/check_release_assets.py
@@ -75,11 +75,13 @@ wheel_projects = {
 
 
 def get_basenames(project, version):
-    locator = distlib.locators.PyPIJSONLocator('https://pypi.org/pypi')
-    proj = locator.get_project(project)
+    # List all wheels including unsupported ones by the current Python
+    distlib.locators.is_compatible = lambda *args: True
+    locator = distlib.locators.SimpleScrapingLocator('https://pypi.org/simple/')
+    proj = locator.get_project(project)['urls']
     if version not in proj:
         return []
-    return [os.path.basename(url) for url in proj[version].download_urls]
+    return [os.path.basename(url) for url in proj[version]]
 
 
 def get_basenames_github(version):


### PR DESCRIPTION
It seems cache expiry for PyPI JSON APIs has extended and we can't get list of files on PyPI immedeately after upload.
Use `SimpleScrapingLocator` to workaround this issue.