### PR TITLE
Reduce memory usage by removing verifier image after each run

### DIFF
--- a/.pfnci/config.pbtxt
+++ b/.pfnci/config.pbtxt
@@ -78,9 +78,9 @@ configs {
   key: "cupy-wheel-linux"
   value {
     requirement {
-      cpu: 16
+      cpu: 8
       gpu: 1
-      memory: 104
+      memory: 64
       disk: 30
     }
     time_limit {

--- a/.pfnci/wheel-linux/main.sh
+++ b/.pfnci/wheel-linux/main.sh
@@ -18,7 +18,7 @@ fi
 git clone --recursive --branch "${BRANCH}" --depth 1 https://github.com/cupy/cupy.git cupy
 
 for PY in $(echo ${PYTHON} | tr ',' ' '); do
-    ./build.sh "${CUDA}" "${PY}"
+    CUPY_RELEASE_VERIFY_REMOVE_IMAGE=1 ./build.sh "${CUDA}" "${PY}"
 done
 
 if [ -z "${JOB_GROUP}" ]; then

--- a/build.sh
+++ b/build.sh
@@ -50,5 +50,8 @@ esac
 ./dist.py --action build  ${DIST_OPTIONS} --source cupy --output .
 
 if [[ "${CUPY_RELEASE_SKIP_VERIFY:-0}" != "1" ]]; then
+  if [[ "${CUPY_RELEASE_VERIFY_REMOVE_IMAGE:-0}" = "1" ]]; then
+    VERIFY_ARGS="${VERIFY_ARGS} --rmi"
+  fi
   ./dist.py --action verify ${DIST_OPTIONS} --dist ${DIST_FILE_NAME} ${VERIFY_ARGS}
 fi

--- a/dist.py
+++ b/dist.py
@@ -114,7 +114,8 @@ class Controller(object):
             help='push builder/verifier Docker images - Linux only')
         parser.add_argument(
             '--rmi', action='store_true', default=False,
-            help='remove builder/verifier Docker images after build - Linux only')
+            help='remove builder/verifier Docker images after build '
+                 '- Linux only')
 
         # Build mode options:
         parser.add_argument(


### PR DESCRIPTION
When building CUDA 11.x wheel, verification step runs against all CUDA versions.
As FlexCI stores Docker images on tmpfs, this leads to excessive memory usage.
This PR changes build stpe to remove verifier Docker image once the step completes successfully.