### PR TITLE
Update check_release_assets.py for v12.0.0rc1/v11.6.0 release

### DIFF
--- a/check_release_assets.py
+++ b/check_release_assets.py
@@ -23,11 +23,11 @@ WINDOWS = 'win_amd64'
 sdist_project = 'cupy'
 
 _v12_cuda_matrix = list(itertools.product(
-    (CP37, CP38, CP39, CP310, CP311), (LINUX, WINDOWS)))
+    (CP38, CP39, CP310, CP311), (LINUX, WINDOWS)))
 _v12_aarch64_matrix = list(itertools.product(
-    (CP37, CP38, CP39, CP310, CP311), (LINUX_AARCH64,)))
+    (CP38, CP39, CP310, CP311), (LINUX_AARCH64,)))
 _v12_rocm_matrix = list(itertools.product(
-    (CP37, CP38, CP39, CP310, CP311), (LINUX,)))
+    (CP38, CP39, CP310, CP311), (LINUX,)))
 
 _v11_cuda_matrix = list(itertools.product(
     (CP37, CP38, CP39, CP310, CP311), (LINUX_V11, WINDOWS)))


### PR DESCRIPTION
Drop support of Python 3.7.