### PR TITLE
Enable cuDNN for CUDA 12.x wheels

### DIFF
--- a/.pfnci/wheel-windows/_flexci.ps1
+++ b/.pfnci/wheel-windows/_flexci.ps1
@@ -55,6 +55,8 @@ function ActivateCUDA($version) {
 function ActivateCuDNN($cudnn_version, $cuda_version) {
     if ($cudnn_version -eq "8.6") {
         $cudnn = "v8.6.0"
+    } elseif ($cudnn_version -eq "8.8") {
+        $cudnn = "v8.8.1"
     } else {
         throw "Unsupported cuDNN version: $cudnn_version"
     }
@@ -63,6 +65,8 @@ function ActivateCuDNN($cudnn_version, $cuda_version) {
         $cuda = "10"
     } elseif ($cuda_version.startswith("11.")) {
         $cuda = "11"
+    } elseif ($cuda_version.startswith("12.")) {
+        $cuda = "12"
     } else {
         throw "Unsupported CUDA version: $cuda_version"
     }

--- a/.pfnci/wheel-windows/build.ps1
+++ b/.pfnci/wheel-windows/build.ps1
@@ -92,12 +92,7 @@ Copy-Item -Path "dll_x64\zlibwapi.dll" -Destination "C:\Windows\System32"
 
 # Verify
 echo ">> Starting verification..."
-if ($cuda -eq "12.x") {
-    # TODO(kmaehashi): cuDNN for CUDA 12 not available yet
-    RunOrDie python ./dist.py --action verify --target wheel-win --python $python --cuda $cuda --dist $wheel_file --test release-tests/common --test release-tests/pkg_wheel
-} else {
-    RunOrDie python ./dist.py --action verify --target wheel-win --python $python --cuda $cuda --dist $wheel_file --test release-tests/common --test release-tests/cudnn --test release-tests/pkg_wheel
-}
+RunOrDie python ./dist.py --action verify --target wheel-win --python $python --cuda $cuda --dist $wheel_file --test release-tests/common --test release-tests/cudnn --test release-tests/pkg_wheel
 
 # Show build configuration in CuPy
 echo ">> Build configuration"

--- a/build.sh
+++ b/build.sh
@@ -26,10 +26,6 @@ case ${CUDA} in
     # CUDA Jetson (wheel)
     VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/cudnn"
     ;;
-  12.x )
-    # CUDA 12.0 (wheel) -- cuDNN not available yet
-    VERIFY_ARGS="${VERIFY_ARGS} --test release-tests/sparse --test release-tests/nccl --test release-tests/pkg_wheel"
-    ;;
   rocm-* )
     # ROCm (wheel)
     VERIFY_ARGS="${VERIFY_ARGS}"

--- a/dist_config.py
+++ b/dist_config.py
@@ -146,9 +146,7 @@ WHEEL_LINUX_CONFIGS = {
         'image': 'cupy/cupy-release-tools:cuda-runfile-12.0.0-centos7',
         'libs': [],
         'includes': [],
-        # TODO(kmaehashi): cuDNN for CUDA 12 not available yet.
-        # 'preloads': ['cutensor', 'nccl', 'cudnn'],
-        'preloads': ['cutensor', 'nccl'],
+        'preloads': ['cutensor', 'nccl', 'cudnn'],
         'verify_image': 'nvidia/cuda:{system}',
         'verify_systems': [
             # Test on all supported CUDA version variants.
@@ -256,8 +254,7 @@ WHEEL_WINDOWS_CONFIGS = {
         'libs': [
             'nvToolsExt64_1.dll',  # NVIDIA Tools Extension Library
         ],
-        # TODO(kmaehashi): cuDNN for CUDA 12 not available yet.
-        'preloads': ['cutensor'],
+        'preloads': ['cutensor', 'cudnn'],
         'cudart_lib': 'cudart64_12',  # binary compatible between CUDA 12.x
         'check_version': lambda x: 12000 <= x < 12010,  # CUDA 12.0
     }

--- a/release-tests/pkg_wheel/test_preload.py
+++ b/release-tests/pkg_wheel/test_preload.py
@@ -15,10 +15,6 @@ class TestPreload(unittest.TestCase):
         return config
 
     def test_cudnn(self):
-        if cupy.cuda.runtime.runtimeGetVersion() == 12000:
-            # TODO(kmaehashi): cuDNN not yet available for CUDA 12.0
-            assert 'cudnn' not in self._get_config()
-            return
         preload_version = self._get_config()['cudnn']['version']
         major, minor, patchlevel = (int(x) for x in preload_version.split('.'))
         expected_version = major * 1000 + minor * 100 + patchlevel


### PR DESCRIPTION
Now that cuDNN 8.8 support is merged (https://github.com/cupy/cupy/pull/7472), `cupy-cuda12x` can be built with cuDNN support enabled.
