### PR TITLE
Bump platform versions used in actions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,10 @@ jobs:
     if: |
         github.repository_owner == 'cupy' &&
         github.event.pull_request.merged == true &&
-        contains(github.event.pull_request.labels.*.name, 'to-be-backported')
+        (
+            (github.event.action == 'closed'  && contains(github.event.pull_request.labels.*.name, 'to-be-backported')) ||
+            (github.event.action == 'labeled' && github.event.label.name == 'to-be-backported')
+        )
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,17 +12,15 @@ jobs:
         github.repository_owner == 'cupy' &&
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'to-be-backported')
-    runs-on: ubuntu-18.04
-    env:
-      CUPY_CI: GitHub
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
@@ -33,7 +31,7 @@ jobs:
         git config --global user.email "33715081+chainer-ci@users.noreply.github.com"
         git clone https://github.com/cupy/backport.git
 
-    - name: run_backport
+    - name: run backport
       env:
         BACKPORT_GITHUB_TOKEN: ${{secrets.BACKPORT_TOKEN}}
       run: |

--- a/.github/workflows/pretest.yml
+++ b/.github/workflows/pretest.yml
@@ -4,19 +4,17 @@ on: [push, pull_request]
 
 jobs:
   pretest:
-    runs-on: ubuntu-18.04
-    env:
-      CUPY_CI: GitHub
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.10'
 
     - name: install
       run: |


### PR DESCRIPTION
https://github.com/cupy/cupy-release-tools/actions/runs/4540244504

Ubuntu 18.04 will stop working on April 1st, 2023.

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

Also bumping software versions to remove deprecation warnings.

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
