### PR TITLE
Install fastrlock to build environment and bump Cython version

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,11 +11,12 @@ RUN yum -y install gcc gcc-c++ make patch git curl && \
 # Install Python.
 ARG python_versions
 ARG cython_version
+ARG fastrlock_version
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
-RUN /setup_python.sh "${python_versions}" "${cython_version}"
+RUN /setup_python.sh "${python_versions}" "${cython_version}" "${fastrlock_version}"
 
 # Install devtoolset (g++) for CuPy v8 build.
 COPY setup_devtoolset.sh /

--- a/builder/Dockerfile.el8
+++ b/builder/Dockerfile.el8
@@ -8,11 +8,12 @@ RUN yum -y install gcc gcc-c++ make patch git curl && \
 # Install Python.
 ARG python_versions
 ARG cython_version
+ARG fastrlock_version
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
-RUN /setup_python.sh "${python_versions}" "${cython_version}"
+RUN /setup_python.sh "${python_versions}" "${cython_version}" "${fastrlock_version}"
 
 # Install additional libraries for CUDA.
 COPY cuda_lib/ /cuda_lib

--- a/builder/Dockerfile.jetson
+++ b/builder/Dockerfile.jetson
@@ -20,11 +20,12 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 # Install Python.
 ARG python_versions
 ARG cython_version
+ARG fastrlock_version
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
 ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
-RUN /setup_python.sh "${python_versions}" "${cython_version}"
+RUN /setup_python.sh "${python_versions}" "${cython_version}" "${fastrlock_version}"
 
 # Install additional libraries for CUDA.
 COPY cuda_lib/ /cuda_lib

--- a/builder/setup_python.sh
+++ b/builder/setup_python.sh
@@ -2,6 +2,7 @@
 
 PYTHON_VERSIONS=$1
 CYTHON_VERSION=$2
+FASTRLOCK_VERSION=$3
 
 if [[ "$(rpm --eval '%{rhel}')" == "7" ]]; then
     # CentOS 7: Use OpenSSL 1.1 for Python 3.10+.
@@ -21,7 +22,7 @@ for VERSION in ${PYTHON_VERSIONS}; do \
     echo "Installing libraries on Python ${VERSION}..."
     pyenv global ${VERSION}
     pip install -U pip setuptools
-    pip install "Cython==${CYTHON_VERSION}" wheel auditwheel
+    pip install "Cython==${CYTHON_VERSION}" "fastrlock==${FASTRLOCK_VERSION}" wheel auditwheel
 done
 
 # The last version installed will be used to run the builder agent.

--- a/dist.py
+++ b/dist.py
@@ -15,6 +15,7 @@ import time
 from dist_config import (
     CUPY_MAJOR_VERSION,
     CYTHON_VERSION,
+    FASTRLOCK_VERSION,
     SDIST_CONFIG,
     SDIST_LONG_DESCRIPTION,
     WHEEL_LINUX_CONFIGS,
@@ -187,6 +188,7 @@ class Controller(object):
             '--build-arg', 'base_image={}'.format(base_image),
             '--build-arg', 'python_versions={}'.format(python_versions),
             '--build-arg', 'cython_version={}'.format(CYTHON_VERSION),
+            '--build-arg', 'fastrlock_version={}'.format(FASTRLOCK_VERSION),
             '--build-arg', 'system_packages={}'.format(system_packages),
             docker_ctx,
             extra_env={'DOCKER_BUILDKIT': '1'},

--- a/dist_config.py
+++ b/dist_config.py
@@ -3,8 +3,9 @@
 # CuPy major version supported by this tool.
 CUPY_MAJOR_VERSION = '13'
 
-# Cython version to cythonize the code.
-CYTHON_VERSION = '0.29.32'
+# Tools to be used for build.
+CYTHON_VERSION = '0.29.34'
+FASTRLOCK_VERSION = '0.8.1'
 
 # Key-value of sdist build settings.
 # See descriptions of WHEEL_LINUX_CONFIGS for details.


### PR DESCRIPTION
This is needed for https://github.com/cupy/cupy/pull/7577 which removes `setup_requires` from `setup.py`.
Note that `python setup.py bdist_wheel` does not respect `pyproject.toml`, so all build requirements must be installed in the current environment.

In future we should consider using `python -m build` instead of `python setup.py bdist_wheel` to use `pyproject.toml`.

Let's merge this one after the release this week.