### PR TITLE
Fix Cython version used for build

### DIFF
--- a/.pfnci/wheel-windows/build.ps1
+++ b/.pfnci/wheel-windows/build.ps1
@@ -56,11 +56,14 @@ echo ">> Using Branch: $branch"
 # Clone CuPy and checkout the target branch
 RunOrDie git clone --recursive --branch $branch --depth 1 https://github.com/cupy/cupy.git cupy
 
+# Get Cython version from configuration.
+$cython_version = @(python -c "import dist_config; print(dist_config.CYTHON_VERSION)")
+
 # Install dependencies
 echo ">> Updating packaging utilities..."
 RunOrDie python -m pip install -U setuptools pip
 echo ">> Installing dependences for wheel build..."
-RunOrDie python -m pip install -U wheel Cython pytest
+RunOrDie python -m pip install -U wheel Cython==${cython_version} pytest
 echo ">> Packages installed:"
 RunOrDie python -m pip list
 

--- a/dist_config.py
+++ b/dist_config.py
@@ -4,7 +4,7 @@
 CUPY_MAJOR_VERSION = '13'
 
 # Tools to be used for build.
-CYTHON_VERSION = '0.29.34'
+CYTHON_VERSION = '0.29.36'
 FASTRLOCK_VERSION = '0.8.1'
 
 # Key-value of sdist build settings.


### PR DESCRIPTION
On Windows, the latest Cython was always used. Instead install Cython version specified in config. (This fixes the wheel build CI failure after Cython 3.0 release)

Also bump Cython version used for wheel build.
https://cython.readthedocs.io/en/latest/src/changes.html#id58
