### PR TITLE
Remove sdist/Linux builds from legacy build submission script

### DIFF
--- a/.pfnci/build_submit.sh
+++ b/.pfnci/build_submit.sh
@@ -8,7 +8,6 @@ BRANCH="$(cat ./.pfnci/BRANCH)"
 JOB_GROUP="$(date +"%F_%T")"
 
 echo "JOB_GROUP = ${JOB_GROUP}"
-echo "URL (Linux) = https://console.cloud.google.com/storage/browser/tmp-asia-pfn-public-ci/cupy-release-tools/build-linux/${JOB_GROUP}_${BRANCH}/"
 echo "URL (Windows) = https://console.cloud.google.com/storage/browser/tmp-asia-pfn-public-ci/cupy-release-tools/build-windows/${JOB_GROUP}_${BRANCH}/"
 
 job_ids=()
@@ -28,14 +27,6 @@ submit_job() {
   # Extract Job ID part from output: "Status: https://ci.preferred.jp/r/job/76261"
   job_ids+=($(basename "${submit_output}"))
 }
-
-# sdist
-submit_job cupy-wheel-linux ".pfnci/wheel-linux/main.sh sdist 3.9 ${BRANCH} ${JOB_GROUP}"
-
-# wheels (Linux)
-for CUDA in 11.x 12.x; do
-  submit_job cupy-wheel-linux ".pfnci/wheel-linux/main.sh ${CUDA} 3.9,3.10,3.11 ${BRANCH} ${JOB_GROUP}"
-done
 
 # wheels (Windows)
 for CUDA in 11.x 12.x; do


### PR DESCRIPTION
We've moved the build process to a new infrastructure, except for Windows.
