### PR TITLE
Preserve symlinks in source tree

### DIFF
--- a/.pfnci/wheel-windows/_flexci.ps1
+++ b/.pfnci/wheel-windows/_flexci.ps1
@@ -102,3 +102,7 @@ function PrioritizeFlexCIDaemon() {
         throw "Failed to change priority of daemon (exit code = $LastExitCode)"
     }
 }
+
+function EnableLongPaths() {
+    Set-ItemProperty "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" -Name LongPathsEnabled -value 1
+}

--- a/.pfnci/wheel-windows/build.ps1
+++ b/.pfnci/wheel-windows/build.ps1
@@ -11,6 +11,7 @@ $ErrorActionPreference = "Stop"
 . "$PSScriptRoot\_flexci.ps1"
 
 PrioritizeFlexCIDaemon
+EnableLongPaths
 
 function UninstallCuDNN($cuda_path) {
     echo "Uninstalling cuDNN installation from ${cuda_path}"
@@ -55,6 +56,8 @@ echo ">> Using Branch: $branch"
 
 # Clone CuPy and checkout the target branch
 RunOrDie git clone --recursive --branch $branch --depth 1 https://github.com/cupy/cupy.git cupy
+RunOrDie git -C cupy config core.symlinks true
+RunOrDie git -C cupy reset --hard
 
 # Get Cython version from configuration.
 $cython_version = @(python -c "import dist_config; print(dist_config.CYTHON_VERSION)")

--- a/dist.py
+++ b/dist.py
@@ -386,7 +386,7 @@ class Controller(object):
 
             # Copy source tree to working directory.
             log('Copying source tree from: {}'.format(source))
-            shutil.copytree(source, '{}/cupy'.format(workdir))
+            shutil.copytree(source, '{}/cupy'.format(workdir), symlinks=True)
 
             # Add long description file.
             with open('{}/description.rst'.format(workdir), 'w') as f:
@@ -541,7 +541,7 @@ class Controller(object):
         try:
             log('Using working directory: {}'.format(workdir))
 
-            # Copy source tree and NCCL to working directory.
+            # Copy source tree to working directory.
             log('Copying source tree from: {}'.format(source))
             shutil.copytree(source, '{}/cupy'.format(workdir))
 


### PR DESCRIPTION
On Linux, invalid symlink (in test suite of CCCL) causes an error when copying CuPy source tree using `shutil.copytree`. This PR fixes the problem by avoid materializing symlinks to real files.

https://github.com/nvidia/cccl/tree/main/libcudacxx/libcxx/test/std/input.output/filesystems/Inputs/static_test_env

```
shutil.Error: [('cupy/cupy/_core/include/cupy/cccl/libcudacxx/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/bad_symlink', '/tmp/cupy-dist-ep2ly0iu/cupy/cupy/_core/include/cupy/cccl/libcudacxx/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/bad_symlink', "[Errno 2] No such file or directory: 'cupy/cupy/_core/include/cupy/cccl/libcudacxx/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/bad_symlink'"), ('cupy/cupy/_core/include/cupy/cccl/libcudacxx/libcxx/test/std/pstl', '/tmp/cupy-dist-ep2ly0iu/cupy/cupy/_core/include/cupy/cccl/libcudacxx/libcxx/test/std/pstl', "[Errno 2] No such file or directory: 'cupy/cupy/_core/include/cupy/cccl/libcudacxx/libcxx/test/std/pstl'")]
```

There is another problem on Windows that copied directory symlinks will become dead, so keep materializing symlinks.