### PR TITLE
Fix builder failure due to CentOS 7 EoL

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,10 +1,15 @@
 ARG base_image
 FROM ${base_image}
 
-RUN yum -y install gcc gcc-c++ make patch git curl && \
+COPY setup_yum_centos7.sh /
+
+# Run twice for EPEL.
+RUN /setup_yum_centos7.sh && \
+    yum -y install gcc gcc-c++ make patch git curl && \
     yum -y install bzip2-devel openssl-devel readline-devel libffi-devel && \
     yum -y install epel-release && \
     yum-config-manager --disable epel && \
+    /setup_yum_centos7.sh && \
     yum -y install --enablerepo=epel openssl11-devel && \
     yum clean all
 
@@ -19,8 +24,10 @@ COPY setup_python.sh /
 RUN /setup_python.sh "${python_versions}" "${cython_version}" "${fastrlock_version}"
 
 # Install devtoolset (g++) for CuPy v8 build.
-COPY setup_devtoolset.sh /
-RUN /setup_devtoolset.sh
+RUN yum install -y centos-release-scl && \
+    /setup_yum_centos7.sh && \
+    yum install -y devtoolset-7-gcc-c++ && \
+    yum clean all
 
 # Install additional libraries for CUDA.
 COPY cuda_lib/ /cuda_lib

--- a/builder/setup_devtoolset.sh
+++ b/builder/setup_devtoolset.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -uex
-
-yum install -y centos-release-scl
-
-# CentOS 7
-yum install -y devtoolset-7-gcc-c++
-
-yum clean all

--- a/builder/setup_yum_centos7.sh
+++ b/builder/setup_yum_centos7.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -uex
+
+sed -i -E -e 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/*.repo
+sed -i -E -e 's|^#( ?)baseurl=http://mirror.centos.org/centos/(7\|\$releasever)/|baseurl=http://ftp.jaist.ac.jp/pub/Linux/CentOS-vault/7.9.2009/|g' /etc/yum.repos.d/*.repo
+sed -i -E -e 's|^#( ?)baseurl=http://download.fedoraproject.org/pub/epel/7/|baseurl=http://ftp.jaist.ac.jp/pub/Linux/Fedora/epel/7/|g' /etc/yum.repos.d/*.repo


### PR DESCRIPTION
`yum` started to fail as CentOS 7 has reached EOL. CuPy binary packages must be built on RHEL 7 variants as we still support CUDA versions that support them (e.g. [CUDA 12.3.2](https://docs.nvidia.com/cuda/archive/12.3.2/cuda-installation-guide-linux/index.html#system-requirements) supports RHEL 7 / CentOS 7).