### PR TITLE
Replace `nvidia-docker run` with `docker run --gpus=all`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ Requirements
 Linux
 ~~~~~
 
-* For ``sdist`` and CUDA (x86_64) wheel build, run the tool on Linux (x86_64). ``nvidia-docker`` and NVIDIA GPU are required for Verify step.
-* For CUDA (JetPack (aarch64)) wheel build, run the tool on Linux (x86_64 with QEMU (aarch64) or Tegra). ``nvidia-docker`` is required for Verify step.
+* For ``sdist`` and CUDA (x86_64) wheel build, run the tool on Linux (x86_64). NVIDIA GPU + NVIDIA Container Toolkit are required for Verify step.
+* For CUDA (aarch64) wheel build, run the tool on Linux (x86_64 with QEMU (aarch64), aarch64, or Tegra). NVIDIA GPU + NVIDIA Container Toolkit is required for Verify step.
 * For ROCm wheel build, run the tool on Linux (x86_64). AMD GPU is required for Verify step.
 
 Notes:

--- a/dist.py
+++ b/dist.py
@@ -267,7 +267,7 @@ class Controller(object):
             image_tag, kind))
         docker_run = ['docker', 'run']
         if kind == 'cuda' and require_runtime:
-            docker_run = ['nvidia-docker', 'run']
+            docker_run += ['--gpus=all']
         elif kind == 'rocm':
             targets = os.environ.get('HCC_AMDGPU_TARGET', None)
             if targets is None:


### PR DESCRIPTION
For historical/intrastructure reasons we had to use `nvidia-docker` here, but it's no longer the case.
