### PR TITLE
Fix CUDA version passed to `_generate_wheel_metadata.py` tool

### DIFF
--- a/dist.py
+++ b/dist.py
@@ -499,9 +499,9 @@ class Controller:
 
             # Create a wheel metadata file for preload.
             if target == 'wheel-linux':
-                assert cuda_version is not None
+                assert preloads_cuda_version is not None
                 wheel_metadata = generate_wheel_metadata(
-                    preloads, cuda_version)
+                    preloads, preloads_cuda_version)
                 log('Writing wheel metadata')
                 with open(
                     f'{workdir}/_wheel.json', 'w', encoding='UTF-8'


### PR DESCRIPTION
The fix same as #436 was also needed for `_generate_wheel_metadata.py` tool :bow:

This is required for aarch64 wheel build. (unfortunately public CI does not cover this case...)