### PR TITLE
Fix invalid long description env var name

### DIFF
--- a/dist.py
+++ b/dist.py
@@ -449,7 +449,10 @@ class Controller:
         ]
 
         # Environmental variables to pass to builder
-        setup_args = ['--env', 'CUPY_INSTALL_LONG_DESCRIPTION=../description.rst']
+        setup_args = [
+            '--env',
+            'CUPY_INSTALL_LONG_DESCRIPTION=../description.rst',
+        ]
         if target == 'wheel-linux':
             setup_args += [
                 '--env',

--- a/dist.py
+++ b/dist.py
@@ -449,7 +449,7 @@ class Controller:
         ]
 
         # Environmental variables to pass to builder
-        setup_args = ['--env', 'CUPY_LONG_DESCRIPTION_PATH=../description.rst']
+        setup_args = ['--env', 'CUPY_INSTALL_LONG_DESCRIPTION=../description.rst']
         if target == 'wheel-linux':
             setup_args += [
                 '--env',
@@ -623,7 +623,7 @@ class Controller:
         # Environmental variables to pass to builder
         agent_args += [
             '--env',
-            'CUPY_INSTALL_LONG_DESCRIPTION_PATH=../description.rst',
+            'CUPY_INSTALL_LONG_DESCRIPTION=../description.rst',
             '--env',
             'CUPY_INSTALL_WHEEL_METADATA=../_wheel.json',
         ]


### PR DESCRIPTION
Follows up #414. The long description of the package was lost in the build artifact.