### PR TITLE
Update builder dependencies

### DIFF
--- a/builder/setup_python.sh
+++ b/builder/setup_python.sh
@@ -22,7 +22,7 @@ for VERSION in ${PYTHON_VERSIONS}; do \
     echo "Installing libraries on Python ${VERSION}..."
     pyenv global ${VERSION}
     pip install -U pip setuptools
-    pip install "Cython==${CYTHON_VERSION}" "fastrlock==${FASTRLOCK_VERSION}" wheel auditwheel build tomli tomli-w
+    pip install -U "Cython==${CYTHON_VERSION}" "fastrlock==${FASTRLOCK_VERSION}" wheel auditwheel build packaging
 done
 
 # The last version installed will be used to run the builder agent.


### PR DESCRIPTION
This workarounds https://github.com/pypa/twine/issues/1216 (`twine check` requires `packaging>=24.2`) and removes unnecessary dependencies.