### PR TITLE
Update `ENV` usage in Dockerfiles

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -19,7 +19,7 @@ ARG cython_version
 ARG fastrlock_version
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
-ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
 RUN /setup_python.sh "${python_versions}" "${cython_version}" "${fastrlock_version}"
 

--- a/builder/Dockerfile.el8
+++ b/builder/Dockerfile.el8
@@ -11,7 +11,7 @@ ARG cython_version
 ARG fastrlock_version
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
-ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
 RUN /setup_python.sh "${python_versions}" "${cython_version}" "${fastrlock_version}"
 

--- a/builder/base/cuda-runfile/Dockerfile
+++ b/builder/base/cuda-runfile/Dockerfile
@@ -12,10 +12,10 @@ RUN curl -sL -o /tmp/cuda_installer "${CUDA_INSTALLER_URL}" && \
     ls -al /usr/local/cuda && \
     rm /tmp/cuda_installer
 
-ENV CUDA_PATH /usr/local/cuda
-ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
-ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+ENV CUDA_PATH=/usr/local/cuda
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 # NVIDIA Container Toolkit (nvidia-docker)
-ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_VISIBLE_DEVICES=all

--- a/verifier/Dockerfile.debian
+++ b/verifier/Dockerfile.debian
@@ -26,7 +26,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 ARG python_versions
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
-ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 RUN for VERSION in ${python_versions}; do \
       echo "Installing Python ${VERSION}..." && \
       pyenv install ${VERSION} & \
@@ -54,7 +54,7 @@ RUN [ -z "${system_packages}" ] || ( \
     )
 
 # Use /tmp as a temporary home to install package.
-ENV HOME /tmp
+ENV HOME=/tmp
 
 # For ROCm 4.3+ (shared libraries are not added to /etc/ld.so.conf.d)
 ENV LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}"

--- a/verifier/Dockerfile.el8
+++ b/verifier/Dockerfile.el8
@@ -11,7 +11,7 @@ RUN yum -y update --nobest && \
 ARG python_versions
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
-ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
 RUN /setup_python.sh "${python_versions}"
 
@@ -23,7 +23,7 @@ RUN [ -z "${system_packages}" ] || ( \
     )
 
 # Use /tmp as a temporary home to install package.
-ENV HOME /tmp
+ENV HOME=/tmp
 
 COPY agent.py /
 COPY setup_cuda_runtime_headers.py /

--- a/verifier/Dockerfile.rhel
+++ b/verifier/Dockerfile.rhel
@@ -14,7 +14,7 @@ RUN yum -y update && \
 ARG python_versions
 RUN git clone https://github.com/pyenv/pyenv.git /opt/pyenv
 ENV PYENV_ROOT=/opt/pyenv
-ENV PATH ${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
+ENV PATH=${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}
 COPY setup_python.sh /
 RUN /setup_python.sh "${python_versions}"
 
@@ -26,7 +26,7 @@ RUN [ -z "${system_packages}" ] || ( \
     )
 
 # Use /tmp as a temporary home to install package.
-ENV HOME /tmp
+ENV HOME=/tmp
 
 COPY agent.py /
 COPY setup_cuda_runtime_headers.py /


### PR DESCRIPTION
Silences Docker warnings:
```
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
```
