### PR TITLE
Fix NCCL preloading

### DIFF
--- a/builder/agent.py
+++ b/builder/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -31,7 +32,7 @@ class BuilderAgent:
     def _run(
         self, *cmd: str, env: Mapping[str, str] | None = None
     ) -> None:
-        self._log(f'Running command: {cmd}')
+        self._log(f'Running command: {shlex.join(cmd)}')
         subprocess.check_call(cmd, env=env)
 
     @staticmethod

--- a/dist.py
+++ b/dist.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import platform
+import shlex
 import shutil
 import subprocess
 import sys
@@ -63,12 +64,12 @@ def run_command(
     if extra_env is not None:
         env = os.environ.copy()
         env.update(extra_env)
-    log(f'Running command: {cmd}')
+    log(f'Running command: {shlex.join(cmd)}')
     subprocess.check_call(cmd, env=env, cwd=cwd, encoding='UTF-8')
 
 
 def run_command_output(*cmd: str, cwd: str | None = None) -> str:
-    log(f'Running command: {cmd}')
+    log(f'Running command: {shlex.join(cmd)}')
     return subprocess.check_output(cmd, cwd=cwd, encoding='UTF-8')
 
 

--- a/verifier/agent.py
+++ b/verifier/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -23,7 +24,7 @@ class VerifierAgent:
         print(f'[VerifierAgent] [{time.asctime()}]: {msg}', flush=True)
 
     def _run(self, *cmd: str) -> None:
-        self._log(f'Running command: {cmd}')
+        self._log(f'Running command: {shlex.join(cmd)}')
         env = dict(os.environ)
         env['CUPY_DEBUG_LIBRARY_LOAD'] = '1'
         subprocess.check_call(cmd, env=env)

--- a/verifier/agent.py
+++ b/verifier/agent.py
@@ -95,16 +95,33 @@ class VerifierAgent:
 
         for p in args.preload:
             assert args.cuda is not None
-            self._log(f'Installing preload libraries ({p})...')
-            cmdline = [
-                *pycommand,
-                '-m',
-                'cupyx.tools.install_library',
-                '--library',
-                p,
-                '--cuda',
-                args.cuda,
-            ]
+            if p == 'nccl':
+                self._log('Installing NCCL library with Pip...')
+                cuda_major = args.cuda.split('.')[0]
+                # TODO(kmaehashi): The version should not be pinned here, but
+                # unfortunately there's no way to extract the NCCL version
+                # supported by CuPy.
+                nccl_package = f'nvidia-nccl-cu{cuda_major}==2.27.7'
+                cmdline = [
+                    *pycommand,
+                    '-m',
+                    'pip',
+                    'install',
+                    nccl_package,
+                ]
+            elif p == 'cutensor':
+                self._log(f'Installing preload library ({p})...')
+                cmdline = [
+                    *pycommand,
+                    '-m',
+                    'cupyx.tools.install_library',
+                    '--library',
+                    p,
+                    '--cuda',
+                    args.cuda,
+                ]
+            else:
+                raise AssertionError(f'Unknown preload library: {p}')
             self._run(*cmdline)
 
         self._log('CuPy Configuration (after preloading)')

--- a/verifier/agent.py
+++ b/verifier/agent.py
@@ -23,7 +23,7 @@ class VerifierAgent:
     def _log(msg: str) -> None:
         print(f'[VerifierAgent] [{time.asctime()}]: {msg}', flush=True)
 
-    def _run(self, *cmd: str, debug_library_load=False) -> None:
+    def _run(self, *cmd: str, debug_library_load: bool = False) -> None:
         self._log(f'Running command: {shlex.join(cmd)}')
         env = dict(os.environ)
         if debug_library_load:

--- a/verifier/agent.py
+++ b/verifier/agent.py
@@ -23,10 +23,11 @@ class VerifierAgent:
     def _log(msg: str) -> None:
         print(f'[VerifierAgent] [{time.asctime()}]: {msg}', flush=True)
 
-    def _run(self, *cmd: str) -> None:
+    def _run(self, *cmd: str, debug_library_load=False) -> None:
         self._log(f'Running command: {shlex.join(cmd)}')
         env = dict(os.environ)
-        env['CUPY_DEBUG_LIBRARY_LOAD'] = '1'
+        if debug_library_load:
+            env['CUPY_DEBUG_LIBRARY_LOAD'] = '1'
         subprocess.check_call(cmd, env=env)
 
     @staticmethod
@@ -90,7 +91,7 @@ class VerifierAgent:
             '-c',
             'import cupy; cupy.show_config()',
         ]
-        self._run(*cmdline)
+        self._run(*cmdline, debug_library_load=True)
 
         for p in args.preload:
             assert args.cuda is not None
@@ -113,11 +114,11 @@ class VerifierAgent:
             '-c',
             'import cupy; cupy.show_config()',
         ]
-        self._run(*cmdline)
+        self._run(*cmdline, debug_library_load=True)
 
         try:
             cmdline = [*pycommand, '-m', 'pytest', *pytest_args]
-            self._run(*cmdline)
+            self._run(*cmdline, debug_library_load=True)
         finally:
             if args.chown:
                 self._log('Resetting owner/group of the source tree...')


### PR DESCRIPTION
This PR changes the verifier to install NCCL with pip instead of `install_library.py`.

Now that CuPy uses cuda-pathfinder, NCCL installed via `install_library.py` will not be used if cuda-pathfinder can discover NCCL from other locations such as `$CUDA_PATH`. However, several `nvidia/cuda` docker images we use for verification (e.g. `nvidia/cuda:12.1.1-runtime-ubuntu22.04`) contains outdated NCCL (e.g. `libnccl2=2.17.1-1+cuda12.1`) which is no longer supported by CuPy. This will cause `import cupy_backends.cuda.libs.nccl` to fail with `undefined symbol: ncclCommSplit` error, causing the wheel verification process to fail.
