### PR TITLE
Use Cython to 3.2.x for wheel build

### DIFF
--- a/builder/requirements.cupy-build.txt
+++ b/builder/requirements.cupy-build.txt
@@ -1,6 +1,6 @@
 # Specific version of dependencies to be used when building CuPy.
 # Must be in sync with CuPy's `pyproject.toml` > `build-system.requires`.
-cython==3.1.4
+cython==3.2.4
 numpy==2.3.5; python_version == '3.14'
 numpy==2.1.3; python_version == '3.13'
 numpy==2.0.2; python_version <= '3.12'


### PR DESCRIPTION
I bumped the cython version to 3.2.4 (>=3.2,<3.3) in the free-threading PR (seemed like no real downside and probably some bug fixes), so follow here.