### PR TITLE
Fix verifier to install always headers in CUDA 12

### DIFF
--- a/verifier/setup_cuda_runtime_headers.py
+++ b/verifier/setup_cuda_runtime_headers.py
@@ -16,11 +16,7 @@ def main() -> None:
 
     # Only install if CUDA 12.2+.
     (major, minor) = cupy.cuda.nvrtc.getVersion()
-    if major == 11:
-        return
-    elif major == 12:
-        if minor < 2:
-            return
+    if major == 12:
         suffix = '-cu12'
     elif major == 13:
         suffix = ''


### PR DESCRIPTION
CUDA headers are now required even for CUDA 12.0/12.1 after https://github.com/cupy/cupy/pull/9853 which removed bundled headers.
